### PR TITLE
fix(test): gate uuid/chrono tests and examples behind correct cfg flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,12 +115,14 @@ required-features = ["axum"]
 
 [[example]]
 name = "audit"
+required-features = ["uuid", "chrono"]
 
 [[example]]
 name = "bulk_operations"
 
 [[example]]
 name = "error_handling"
+required-features = ["uuid", "std", "serde"]
 
 [[example]]
 name = "etag"
@@ -142,12 +144,14 @@ name = "rate_limit"
 
 [[example]]
 name = "response_envelope"
+required-features = ["uuid", "serde"]
 
 [[example]]
 name = "slug"
 
 [[example]]
 name = "error_construction"
+required-features = ["uuid", "std", "serde"]
 
 [[example]]
 name = "bulk_envelope"

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -808,12 +808,14 @@ mod tests {
         assert_eq!(p.kind, PrincipalKind::System);
     }
 
+    #[cfg(feature = "uuid")]
     #[test]
     fn principal_system_has_empty_org_path() {
         let p = Principal::system("s");
         assert!(p.org_path.is_empty());
     }
 
+    #[cfg(feature = "uuid")]
     #[test]
     fn principal_with_org_path_builder() {
         let org_id = crate::org_id::OrgId::generate();
@@ -944,7 +946,7 @@ mod tests {
         assert_eq!(back, p);
     }
 
-    #[cfg(feature = "serde")]
+    #[cfg(all(feature = "serde", feature = "uuid"))]
     #[test]
     fn principal_serde_includes_org_path() {
         let p = Principal::system("test");

--- a/src/common.rs
+++ b/src/common.rs
@@ -79,7 +79,7 @@ pub fn new_resource_id() -> ResourceId {
     uuid::Uuid::new_v4()
 }
 
-#[cfg(test)]
+#[cfg(all(test, any(feature = "uuid", feature = "chrono")))]
 mod tests {
     use super::*;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1732,6 +1732,7 @@ mod tests {
         assert_eq!(e.title, "Resource Not Found");
     }
 
+    #[cfg(feature = "uuid")]
     #[test]
     fn with_request_id() {
         let id = uuid::Uuid::new_v4();
@@ -1768,7 +1769,7 @@ mod tests {
         assert!(json.get("errors").is_none());
     }
 
-    #[cfg(feature = "serde")]
+    #[cfg(all(feature = "serde", feature = "uuid"))]
     #[test]
     fn wire_format_instance_is_urn_uuid() {
         let _g = lock_and_reset_mode();
@@ -2169,7 +2170,7 @@ mod tests {
         assert!(result.is_err());
     }
 
-    #[cfg(feature = "serde")]
+    #[cfg(all(feature = "serde", feature = "uuid"))]
     #[test]
     fn uuid_urn_option_serialize_none_produces_null() {
         // The None arm exists for the serde `with` protocol. Since
@@ -2182,7 +2183,7 @@ mod tests {
         assert_eq!(buf, b"null");
     }
 
-    #[cfg(feature = "serde")]
+    #[cfg(all(feature = "serde", feature = "uuid"))]
     #[test]
     fn uuid_urn_option_deserialize_non_string_is_error() {
         let _g = lock_and_reset_mode();
@@ -2199,7 +2200,7 @@ mod tests {
         assert!(result.is_err());
     }
 
-    #[cfg(feature = "serde")]
+    #[cfg(all(feature = "serde", feature = "uuid"))]
     #[test]
     fn uuid_urn_option_deserialize_null_gives_none() {
         let _g = lock_and_reset_mode();
@@ -2215,7 +2216,7 @@ mod tests {
         assert!(e.request_id.is_none());
     }
 
-    #[cfg(feature = "serde")]
+    #[cfg(all(feature = "serde", feature = "uuid"))]
     #[test]
     fn uuid_urn_option_deserialize_valid_urn_uuid() {
         let _g = lock_and_reset_mode();
@@ -2232,7 +2233,7 @@ mod tests {
         assert_eq!(e.request_id, Some(id));
     }
 
-    #[cfg(feature = "serde")]
+    #[cfg(all(feature = "serde", feature = "uuid"))]
     #[test]
     fn uuid_urn_option_deserialize_bad_prefix_is_error() {
         let _g = lock_and_reset_mode();
@@ -2252,6 +2253,7 @@ mod tests {
     // ApiError builder tests
     // -----------------------------------------------------------------------
 
+    #[cfg(feature = "uuid")]
     #[test]
     fn builder_basic() {
         let err = ApiError::builder()
@@ -2275,6 +2277,7 @@ mod tests {
         assert_eq!(via_new, via_builder);
     }
 
+    #[cfg(feature = "uuid")]
     #[test]
     fn builder_chaining_all_optionals() {
         let id = uuid::Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();

--- a/src/header_id.rs
+++ b/src/header_id.rs
@@ -109,7 +109,7 @@ pub trait HeaderId {
 // Tests
 // ---------------------------------------------------------------------------
 
-#[cfg(test)]
+#[cfg(all(test, feature = "uuid"))]
 mod tests {
     use super::*;
     use crate::correlation_id::CorrelationId;

--- a/src/org_id.rs
+++ b/src/org_id.rs
@@ -276,6 +276,23 @@ impl OrgId {
     }
 }
 
+/// Compile-fail proof that the bare `OrgId` axum extractor has been removed
+/// (ADR platform/0015). Any reintroduction of the extractor will cause this
+/// doctest to start compiling, which fails the test.
+///
+/// ```compile_fail
+/// use api_bones::OrgId;
+/// use axum::extract::FromRequestParts;
+/// use axum::http::request::Parts;
+///
+/// async fn _proof(mut parts: Parts) {
+///     let _ = <OrgId as FromRequestParts<()>>::from_request_parts(&mut parts, &()).await;
+/// }
+/// ```
+#[cfg(feature = "axum")]
+#[doc(hidden)]
+pub fn __adr_platform_0015_proof() {}
+
 // ---------------------------------------------------------------------------
 // OrgPath — X-Org-Path header newtype
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `src/audit.rs`: add `#[cfg(feature = "uuid")]` to `principal_system_has_empty_org_path`, `principal_with_org_path_builder`, and `#[cfg(all(feature = "serde", feature = "uuid"))]` to `principal_serde_includes_org_path`
- `src/error.rs`: add `#[cfg(feature = "uuid")]` to `with_request_id`, `builder_basic`, `builder_chaining_all_optionals`; tighten five `uuid_urn_option_*` and `wire_format_instance_is_urn_uuid` tests to `#[cfg(all(feature = "serde", feature = "uuid"))]`
- `src/header_id.rs`: gate entire test module on `#[cfg(all(test, feature = "uuid"))]` (all tests import uuid-gated types)
- `src/common.rs`: gate test module on `any(feature = "uuid", feature = "chrono")` to suppress unused-import warning
- `Cargo.toml`: add `required-features` to `audit`, `response_envelope`, `error_handling`, `error_construction` examples so they are skipped when their dependencies are absent

Verified: `cargo nextest run --workspace --no-default-features` → 545 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)