### PR TITLE
docs: use role-based email aliases in CoC and SECURITY

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at **gregoire.salingue@pm.me**. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at **conduct@brefwiz.com**. All complaints will be reviewed and investigated promptly and fairly.
 
 ## Attribution
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,7 @@
 
 **Do not open a public GitHub issue for security vulnerabilities.**
 
-Please report security issues by email to **gregoire.salingue@pm.me**.
+Please report security issues by email to **security@brefwiz.com**.
 
 Include:
 - A description of the vulnerability


### PR DESCRIPTION
## Summary

- `SECURITY.md` now points to `security@brefwiz.com` instead of a personal maintainer email
- `CODE_OF_CONDUCT.md` now points to `conduct@brefwiz.com`
- Role-based aliases let the recipient list rotate without touching the repo

## Test plan

- [x] Visual diff review of the two files
- [x] Confirm `security@brefwiz.com` and `conduct@brefwiz.com` route to a monitored inbox before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)