### PR TITLE
chore: add Dependabot (cargo + actions)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` with weekly updates for Cargo dependencies and GitHub Actions (Mondays)
- CodeQL already present — no changes needed there

## Test plan

- [x] YAML syntax valid
- [x] Covers both `cargo` and `github-actions` ecosystems

🤖 Generated with [Claude Code](https://claude.com/claude-code)