### PR TITLE
chore: release v4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.1] - 2026-04-21
+
+### Changed
+
+- Upgraded optional dependencies: `rand 0.9 → 0.10`, `hmac 0.12 → 0.13`, `fake 3 → 5`,
+  `sha2 0.10 → 0.11`, `validator 0.18 → 0.20`, `uuid 1.11 → 1.23`,
+  `reqwest 0.12 → 0.13` (in `api-bones-reqwest`). All are internal to optional feature
+  flags and not exposed in the public API.
+- CI: Dependabot enabled for Cargo and GitHub Actions.
+- CI: CodeQL scanning workflow added with false-positive suppression config.
+- CI: Workflow permissions hardened (`contents: read` default; `tag.yml` minimal grant).
+
+### Fixed
+
+- CI workflow permissions were overly broad (no explicit `permissions:` block). Now
+  locked to least privilege per job.
+
 ## [4.0.0] - 2026-04-20
 
 ### BREAKING CHANGE

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-bones"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "arbitrary",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "api-bones"
-version = "4.0.0"
+version = "4.0.1"
 edition = "2024"
 authors = ["Gregoire Salingue"]
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bump `api-bones` version `4.0.0 → 4.0.1`
- Add CHANGELOG entry for v4.0.1 (dep upgrades, CI hardening, CodeQL)

## Test plan

- [ ] `make ci-format` passes
- [ ] `make ci-lint` passes
- [ ] After merge: tag `v4.0.1` and run `cargo publish`

🤖 Generated with [Claude Code](https://claude.com/claude-code)