### PR TITLE
ci: add weekly scheduled run for security audit and allowlist review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  schedule:
+    - cron: "0 6 * * 1"   # weekly Monday 06:00 UTC — surfaces expired allowlist entries and new advisories
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Adds a `schedule` trigger (`0 6 * * 1` — every Monday 06:00 UTC) to the CI workflow
- Ensures `cargo audit` + `cargo deny check` (via shared-ci-workflows) run weekly, not only on push/PR
- This surfaces new advisories and expired `review-by` allowlist entries proactively

## Context

The `shared-ci-workflows/policies/deny.toml` central allowlist uses a 90-day `review-by` contract enforced by `check-policy-expiry.sh`. Without a scheduled run, expiry is only caught when someone opens a PR — this makes the periodic check actually periodic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)