### PR TITLE
chore: release v4.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.2] - 2026-04-23
+
+### Security
+
+- Bumped transitive dependency `rand 0.9.2 → 0.9.4` (RUSTSEC-2026-0097 / GHSA-cq8v-f236-94qc):
+  unsound aliased mutable reference when a custom logger calls `rand::rng()` during reseeding.
+  This crate's own code was not affected (rand is only used via the optional `fake` feature and
+  dev-dependencies); the lock-file pin eliminates the vulnerable version entirely.
+
+### Changed
+
+- CI: weekly scheduled run added for security audit and Dependabot allowlist review.
+
 ## [4.0.1] - 2026-04-21
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-bones"
-version = "4.0.1"
+version = "4.0.2"
 dependencies = [
  "arbitrary",
  "axum",
@@ -959,7 +959,7 @@ dependencies = [
  "hyper-util",
  "log",
  "pin-project-lite",
- "rand 0.9.2",
+ "rand 0.9.4",
  "regex",
  "serde_json",
  "serde_urlencoded",
@@ -1124,7 +1124,7 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -1173,9 +1173,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "api-bones"
-version = "4.0.1"
+version = "4.0.2"
 edition = "2024"
 authors = ["Gregoire Salingue"]
 license = "MIT"


### PR DESCRIPTION
## Summary

- Pin transitive `rand 0.9.2 → 0.9.4` (RUSTSEC-2026-0097 / GHSA-cq8v-f236-94qc): unsound aliased mutable reference when a custom logger calls `rand::rng()` during reseeding. Vulnerability came via the `mockito` dev-dependency; this crate's own code is not affected.
- CI: weekly scheduled run for security audit and Dependabot allowlist review (#21).
- Bump version `4.0.1 → 4.0.2`.

Closes #3 (Dependabot alert).

## Test plan

- [x] `cargo test --no-run` passes clean
- [x] `cargo tree -i rand` confirms `rand v0.9.4` — no 0.9.2 in the tree
- [x] CHANGELOG updated with `### Security` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)