### PR TITLE
chore: release v4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.1.0] - 2026-04-24
+
+### Added
+
+- `ApiResponse<T>` now implements `Deref<Target = T>`, giving transparent method and
+  field access on the payload without going through `.data` (`response.len()`,
+  `response.name`, etc.).
+- `ApiResponse::into_inner(self) -> T` — consume the envelope and return the payload,
+  discarding metadata. Follows the std convention used by `Mutex`, `RefCell`, and
+  `BufReader`.
+
 ## [4.0.2] - 2026-04-23
 
 ### Security

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-bones"
-version = "4.0.2"
+version = "4.1.0"
 dependencies = [
  "arbitrary",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "api-bones"
-version = "4.0.2"
+version = "4.1.0"
 edition = "2024"
 authors = ["Gregoire Salingue"]
 license = "MIT"

--- a/src/response.rs
+++ b/src/response.rs
@@ -224,6 +224,42 @@ impl proptest::arbitrary::Arbitrary for ResponseMeta {
 /// same top-level JSON shape.  Use [`ApiResponse::builder`] for ergonomic
 /// construction.
 ///
+/// # Ergonomic access
+///
+/// `ApiResponse<T>` implements [`Deref<Target = T>`](std::ops::Deref) so method
+/// and field access on the payload works transparently without `.data`:
+///
+/// ```rust
+/// use api_bones::response::ApiResponse;
+///
+/// let r: ApiResponse<String> = ApiResponse::builder("hello".to_string()).build();
+/// assert_eq!(r.len(), 5);        // String::len via Deref
+/// assert_eq!(&*r, "hello");      // explicit deref
+/// ```
+///
+/// To move the payload out and discard the envelope:
+///
+/// ```rust
+/// use api_bones::response::ApiResponse;
+///
+/// let r: ApiResponse<i32> = ApiResponse::builder(42).build();
+/// let val: i32 = r.into_inner();
+/// assert_eq!(val, 42);
+/// ```
+///
+/// To access envelope metadata alongside the payload:
+///
+/// ```rust
+/// use api_bones::response::ApiResponse;
+///
+/// let r: ApiResponse<i32> = ApiResponse::builder(1).build();
+/// let _req_id = &r.meta.request_id;          // envelope field
+/// let ApiResponse { data, meta, .. } = r;    // destructure
+/// ```
+///
+/// [`DerefMut`](std::ops::DerefMut) is intentionally not implemented; mutate
+/// after calling `into_inner()`.
+///
 /// # Composing with `PaginatedResponse`
 ///
 /// ```rust
@@ -350,6 +386,29 @@ impl<T> ApiResponse<T> {
             links: None,
         }
     }
+
+    /// Consume the envelope and return the payload, discarding metadata.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use api_bones::response::ApiResponse;
+    ///
+    /// let r: ApiResponse<i32> = ApiResponse::builder(42).build();
+    /// assert_eq!(r.into_inner(), 42);
+    /// ```
+    #[must_use]
+    pub fn into_inner(self) -> T {
+        self.data
+    }
+}
+
+impl<T> std::ops::Deref for ApiResponse<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.data
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -420,6 +479,23 @@ mod tests {
                 .map(|l| l.href.as_str()),
             Some("/items/1")
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Deref / into_inner / From
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn deref_gives_transparent_payload_access() {
+        let r: ApiResponse<String> = ApiResponse::builder("hello".to_string()).build();
+        assert_eq!(r.len(), 5); // String::len resolved via Deref
+        assert_eq!(&*r, "hello");
+    }
+
+    #[test]
+    fn into_inner_moves_payload() {
+        let r: ApiResponse<i32> = ApiResponse::builder(42).build();
+        assert_eq!(r.into_inner(), 42);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `ApiResponse<T>` implements `Deref<Target = T>` — transparent method and field access on the payload without `.data`
- `ApiResponse::into_inner(self) -> T` — consume the envelope and return the payload, following std convention (`Mutex`, `RefCell`, `BufReader`)
- CHANGELOG and version bump to 4.1.0

## Motivation

ADR-0016 introduced `ApiResponse<T>` as the canonical response envelope, but callers had to always reach through `.data` to access the payload. This adds the ergonomic layer the CTO recommended: `Deref` for the 80% case, `into_inner()` for move-out.

## Test plan

- [x] `deref_gives_transparent_payload_access` — method call via Deref
- [x] `into_inner_moves_payload` — move-out
- [x] All 29 existing response tests pass
- [x] Inline doc examples compile (`cargo test --doc`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)