### PR TITLE
fix(axios): skipLibCheck to fix tsc build in CI

### DIFF
--- a/api-bones-axios/tsconfig.json
+++ b/api-bones-axios/tsconfig.json
@@ -6,7 +6,9 @@
     "declaration": true,
     "outDir": "dist",
     "rootDir": "src",
-    "strict": true
+    "strict": true,
+    "skipLibCheck": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "node_modules"]
 }


### PR DESCRIPTION
## Summary

- Add `skipLibCheck: true` to `api-bones-axios/tsconfig.json` — suppresses type errors from `vitest`/`vite` dev dependency declarations that require `@types/node` (which a browser/runtime-agnostic library doesn't need)
- Exclude test files from the `tsc` build output

## Test plan

- `npm run build` in `api-bones-axios/` exits clean
- `dist/` only contains source files, not test artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)