### PR TITLE
fix(axios): accept real axios instances in addEnvelopeUnwrapInterceptor

### DIFF
--- a/api-bones-axios/CHANGELOG.md
+++ b/api-bones-axios/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to `@brefwiz/api-bones-axios` are documented here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.1] — 2026-04-24
+
+### Fixed
+- `addEnvelopeUnwrapInterceptor` now accepts the real axios default export (`AxiosStatic`) and any `AxiosInstance` without a type error. Previously, the structural `AxiosLikeInstance` type used `AxiosInterceptorManager<EnvelopeAxiosResponse>` which was incompatible with axios's native `AxiosInterceptorManager<AxiosResponse>` instantiation.
+- Removed the unused `[key: string]: unknown;` index signature from `EnvelopeAxiosRequestConfig`; it blocked assignment from axios's `InternalAxiosRequestConfig`.
+
+## [0.1.0] — 2026-04-23
+
+### Added
+- Initial release: `addEnvelopeUnwrapInterceptor`, `getEnvelopeMeta`, `getEnvelopeLinks`, and structural types for the `api_bones::response::ApiResponse` envelope.

--- a/api-bones-axios/package-lock.json
+++ b/api-bones-axios/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brefwiz/api-bones-axios",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brefwiz/api-bones-axios",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.0.0",

--- a/api-bones-axios/package.json
+++ b/api-bones-axios/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brefwiz/api-bones-axios",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Axios interceptor for transparent ApiResponse envelope stripping in Brefwiz SDKs",
   "author": "Brefwiz Team",
   "license": "MIT",

--- a/api-bones-axios/src/index.ts
+++ b/api-bones-axios/src/index.ts
@@ -29,7 +29,6 @@ export interface ApiResponseEnvelope<T = unknown> {
 export interface EnvelopeAxiosRequestConfig {
   _envelopeMeta?: ResponseMeta;
   _envelopeLinks?: Links | null;
-  [key: string]: unknown;
 }
 
 export interface EnvelopeAxiosResponse {
@@ -47,9 +46,13 @@ export interface AxiosInterceptorManager<V> {
   eject(id: number): void;
 }
 
+// Widened `V` to `any` so real axios instances (whose interceptor is typed for
+// `AxiosResponse`, not `EnvelopeAxiosResponse`) are structurally assignable.
+// The interceptor callback internally treats the value as `EnvelopeAxiosResponse`.
 export interface AxiosLikeInstance {
   interceptors: {
-    response: AxiosInterceptorManager<EnvelopeAxiosResponse>;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    response: AxiosInterceptorManager<any>;
   };
 }
 


### PR DESCRIPTION
## Summary

- `AxiosLikeInstance.interceptors.response` was typed `AxiosInterceptorManager<EnvelopeAxiosResponse>` — incompatible with axios's native `AxiosInterceptorManager<AxiosResponse>`, so `addEnvelopeUnwrapInterceptor(axios)` (the exact call the generated SDK makes) failed to type-check.
- `EnvelopeAxiosRequestConfig` had an unused `[key: string]: unknown;` index signature that blocked assignment from axios's `InternalAxiosRequestConfig`.
- Widened the interceptor's value type to `any` and removed the index signature. Bumps `@brefwiz/api-bones-axios` 0.1.0 → 0.1.1.

Unblocks itinerwiz CI `ci-sdk-prebuild-typescript`, which was failing with `TS2345: Argument of type 'AxiosStatic' is not assignable to parameter of type 'AxiosLikeInstance'`.

## Test plan

- [x] `npm run build` passes (tsc clean)
- [x] `npm test` — 3/3 vitest tests pass
- [x] Smoke test: `addEnvelopeUnwrapInterceptor(axios)` and `addEnvelopeUnwrapInterceptor(axios.create())` both type-check under `--strict`
- [ ] Consumer verification: itinerwiz `ci-sdk-prebuild-typescript` after this is published

🤖 Generated with [Claude Code](https://claude.com/claude-code)