### PR TITLE
ci(release): independent axios-v* tag cadence for npm package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,18 @@
 name: Release
 
+# Rust crates release on `v*` tags (e.g. v4.3.0).
+# The `@brefwiz/api-bones-axios` npm package releases on `axios-v*` tags
+# (e.g. axios-v0.1.1) so its cadence is independent of the Rust workspace.
 on:
   push:
-    tags: ['v*']
+    tags:
+      - 'v*'
+      - 'axios-v*'
 
 jobs:
   release-rust:
+    # Only run on pure `v*` tags (not `axios-v*`, which starts with `a`).
+    if: startsWith(github.ref, 'refs/tags/v')
     uses: brefwiz/shared-ci-workflows/.github/workflows/release-rust.yml@main
     with:
       # Publish in dependency order: api-bones must land on crates.io before
@@ -16,7 +23,26 @@ jobs:
     permissions:
       contents: write
 
+  validate-axios-tag:
+    # Guard against publishing a version that doesn't match the tag.
+    if: startsWith(github.ref, 'refs/tags/axios-v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify axios-v<version> matches package.json
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/axios-v}"
+          PKG_VERSION="$(node -p "require('./api-bones-axios/package.json').version")"
+          echo "Tag version:     ${TAG_VERSION}"
+          echo "Package version: ${PKG_VERSION}"
+          if [ "${TAG_VERSION}" != "${PKG_VERSION}" ]; then
+            echo "::error::tag axios-v${TAG_VERSION} does not match api-bones-axios/package.json version ${PKG_VERSION}"
+            exit 1
+          fi
+
   release-npm:
+    needs: validate-axios-tag
+    if: startsWith(github.ref, 'refs/tags/axios-v')
     uses: brefwiz/shared-ci-workflows/.github/workflows/release-npm.yml@main
     with:
       packages: "api-bones-axios"

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -7,7 +7,45 @@ on:
 permissions: {}
 
 jobs:
+  # Rust workspace version → v<X.Y.Z> tag
   tag:
     uses: brefwiz/shared-ci-workflows/.github/workflows/auto-tag.yml@main
     secrets:
       release-token: ${{ secrets.RELEASE_TOKEN }}
+
+  # api-bones-axios npm package version → axios-v<X.Y.Z> tag (independent cadence)
+  tag-axios:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN }}
+
+      - name: Read axios package version
+        id: version
+        run: |
+          VERSION="$(node -p "require('./api-bones-axios/package.json').version")"
+          echo "tag=axios-v${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Detected axios version: ${VERSION}"
+
+      - name: Check whether tag already exists
+        id: tag_check
+        run: |
+          if git tag --list "${{ steps.version.outputs.tag }}" | grep -q .; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Tag ${{ steps.version.outputs.tag }} already exists — skipping."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create and push tag
+        if: steps.tag_check.outputs.exists == 'false'
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "${{ steps.version.outputs.tag }}"
+          git push origin "${{ steps.version.outputs.tag }}"
+          echo "Pushed tag ${{ steps.version.outputs.tag }}"


### PR DESCRIPTION
## Summary

The Rust workspace and `@brefwiz/api-bones-axios` share a single `v*` tag trigger, which breaks npm publishing:

- **No independent cadence** — can't release the npm package without tagging a Rust version.
- **Version drift** — the version in `api-bones-axios/package.json` is decoupled from the git tag, so every Rust-only release either silently re-publishes the same npm version (currently 0.1.0 has never landed so it's a no-op) or will hit 409 Conflict once 0.1.0 is actually published.

This PR splits the release cadences:

- `v*` → Rust crates (unchanged)
- `axios-v*` → `@brefwiz/api-bones-axios` (new, validated against `package.json`)

`tag.yml` now carries a second job that reads `api-bones-axios/package.json` on every push to main and creates `axios-v<version>` when the version bumps. `release.yml` gates `release-npm` on a `validate-axios-tag` job that aborts if the tag does not match `package.json`, preventing silent mismatches.

Context: unblocks itinerwiz `ci-sdk-prebuild-typescript`. The #28 fix bumps `api-bones-axios` to 0.1.1 — once both PRs merge, auto-tag will create `axios-v0.1.1` and `release-npm` will publish for the first time.

## Test plan

- [ ] Merge PR #28 first (bumps package.json to 0.1.1)
- [ ] Merge this PR → auto-tag creates `axios-v0.1.1` → `release-npm` publishes `@brefwiz/api-bones-axios@0.1.1` to GitHub Packages
- [ ] Verify itinerwiz `ci-sdk-prebuild-typescript` passes against the published package
- [ ] Future Rust-only release (next `v*` tag) should skip `release-npm` as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)