### PR TITLE
fix(progenitor): unwrap envelope schema when response uses $ref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.2.1] - 2026-04-24
+
+### Fixed
+
+- **`api-bones-progenitor`**: `unwrap_api_response_envelope` now follows `$ref` pointers to
+  component schemas when rewriting response schemas. Previously only inline envelope schemas
+  were unwrapped; services whose OpenAPI spec uses `$ref: "#/components/schemas/ApiResponse_*"`
+  (the common utoipa output) got no schema rewrite, causing progenitor to generate types that
+  still expected the full envelope while the HTTP hook sent only the stripped `data` payload —
+  resulting in deserialization failures at runtime.
+
 ## [4.2.0] - 2026-04-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-bones"
-version = "4.2.0"
+version = "4.2.1"
 dependencies = [
  "arbitrary",
  "axum",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "api-bones-progenitor"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "openapiv3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "api-bones"
-version = "4.2.0"
+version = "4.2.1"
 edition = "2024"
 authors = ["Gregoire Salingue"]
 license = "MIT"

--- a/api-bones-progenitor/Cargo.toml
+++ b/api-bones-progenitor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api-bones-progenitor"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 authors = ["Gregoire Salingue"]
 license = "MIT"

--- a/api-bones-progenitor/src/lib.rs
+++ b/api-bones-progenitor/src/lib.rs
@@ -126,7 +126,18 @@ fn normalize_nullable(val: &mut serde_json::Value) {
 
 /// Replace every operation response body schema that matches the `ApiResponse`
 /// envelope shape with just the inner `data` sub-schema.
+///
+/// Handles both inline envelope schemas and `$ref` pointers to component schemas
+/// that have the envelope shape.
 fn unwrap_api_response_envelope(raw: &mut serde_json::Value) {
+    // Snapshot component schemas so we can resolve $refs without borrowing `raw` mutably.
+    let components: std::collections::HashMap<String, serde_json::Value> = raw
+        .get("components")
+        .and_then(|c| c.get("schemas"))
+        .and_then(|s| s.as_object())
+        .map(|m| m.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
+        .unwrap_or_default();
+
     let paths = match raw.get_mut("paths").and_then(|p| p.as_object_mut()) {
         Some(p) => p,
         None => return,
@@ -145,10 +156,23 @@ fn unwrap_api_response_envelope(raw: &mut serde_json::Value) {
                 None => continue,
             };
             for (_status, response) in responses.iter_mut() {
-                if let Some(schema) = response.pointer_mut("/content/application~1json/schema")
-                    && let Some(inner) = extract_envelope_data(schema)
-                {
-                    *schema = inner;
+                if let Some(schema) = response.pointer_mut("/content/application~1json/schema") {
+                    if let Some(inner) = extract_envelope_data(schema) {
+                        *schema = inner;
+                    } else if let Some(ref_str) = schema
+                        .get("$ref")
+                        .and_then(|r| r.as_str())
+                        .map(str::to_owned)
+                    {
+                        let component_name = ref_str
+                            .strip_prefix("#/components/schemas/")
+                            .unwrap_or(&ref_str);
+                        if let Some(component) = components.get(component_name)
+                            && let Some(inner) = extract_envelope_data(component)
+                        {
+                            *schema = inner;
+                        }
+                    }
                 }
             }
         }
@@ -248,6 +272,52 @@ mod tests {
         assert_eq!(
             schema, &plain,
             "non-envelope schema should pass through unchanged"
+        );
+    }
+
+    #[test]
+    fn envelope_unwrap_follows_ref_to_component() {
+        let inner = serde_json::json!({ "type": "string" });
+        let mut spec = serde_json::json!({
+            "openapi": "3.1.0",
+            "info": { "title": "test", "version": "0.0.1" },
+            "paths": {
+                "/items": {
+                    "get": {
+                        "operationId": "list_items",
+                        "responses": {
+                            "200": {
+                                "description": "ok",
+                                "content": {
+                                    "application/json": {
+                                        "schema": { "$ref": "#/components/schemas/ApiResponse_Item" }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "components": {
+                "schemas": {
+                    "ApiResponse_Item": {
+                        "properties": {
+                            "data": inner,
+                            "meta": { "type": "object" }
+                        },
+                        "required": ["data", "meta"]
+                    }
+                }
+            }
+        });
+        unwrap_api_response_envelope(&mut spec);
+        let schema = spec
+            .pointer("/paths/~1items/get/responses/200/content/application~1json/schema")
+            .unwrap();
+        assert_eq!(
+            schema,
+            &serde_json::json!({ "type": "string" }),
+            "should unwrap $ref to envelope component"
         );
     }
 


### PR DESCRIPTION
## Summary

- `unwrap_api_response_envelope` now follows `$ref` pointers to `#/components/schemas/*` when rewriting response schemas before codegen
- Fixes a silent mismatch: utoipa emits `$ref: ApiResponse_*` for all responses; the old code only handled inline schemas, so generated types retained the full envelope shape while the HTTP hook already stripped the body to just `data` — causing deserialization failures (500s) at runtime
- Bumps `api-bones-progenitor` to **0.1.1**

## Test plan

- [x] New test `envelope_unwrap_follows_ref_to_component` — 5/5 pass
- [x] Existing tests unchanged
- [x] Verified in quorate: SDK rebuilds with correct types after this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)