### PR TITLE
chore: align all crates to v4.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.4.0] — 2026-04-25
+
+### Added
+
+- **`api-bones-sdk-gen`** — new crate (CLI) for generating Brefwiz Rust + TypeScript SDKs
+  with default-on `ApiResponse` envelope handling.
+- **`api-bones-sdk-gen`: `rewrite_envelope_types`** post-processing step rewrites
+  `AxiosPromise<XxxResponse>` → `AxiosPromise<XxxResponseData>` in generated `api.ts` so
+  `resp.data` is statically typed as the unwrapped payload after the axios interceptor runs.
+- **`api-bones-progenitor`** — envelope-stripping `ClientHooks` for progenitor-generated
+  Rust SDKs.
+
+### Changed
+
+- All satellite crates (`api-bones-tower`, `api-bones-reqwest`, `api-bones-progenitor`,
+  `api-bones-sdk-gen`) aligned to the workspace version (`4.4.0`).
+
 ## [4.3.0] - 2026-04-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-bones"
-version = "4.3.0"
+version = "4.4.0"
 dependencies = [
  "arbitrary",
  "axum",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "api-bones-progenitor"
-version = "0.1.1"
+version = "4.4.0"
 dependencies = [
  "anyhow",
  "openapiv3",
@@ -122,7 +122,7 @@ dependencies = [
 
 [[package]]
 name = "api-bones-reqwest"
-version = "2.0.3"
+version = "4.4.0"
 dependencies = [
  "api-bones",
  "mockito",
@@ -135,7 +135,7 @@ dependencies = [
 
 [[package]]
 name = "api-bones-sdk-gen"
-version = "0.2.0"
+version = "4.4.0"
 dependencies = [
  "anyhow",
  "api-bones-progenitor",
@@ -145,7 +145,7 @@ dependencies = [
 
 [[package]]
 name = "api-bones-tower"
-version = "2.0.3"
+version = "4.4.0"
 dependencies = [
  "api-bones",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "api-bones"
-version = "4.3.0"
+version = "4.4.0"
 edition = "2024"
 authors = ["Gregoire Salingue"]
 license = "MIT"

--- a/api-bones-axios/CHANGELOG.md
+++ b/api-bones-axios/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to `@brefwiz/api-bones-axios` are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.4.0] — 2026-04-25
+
+### Changed
+
+- Version aligned with the `api-bones` workspace (`4.4.0`). No functional changes.
+
 ## [0.1.1] — 2026-04-24
 
 ### Fixed

--- a/api-bones-axios/package.json
+++ b/api-bones-axios/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brefwiz/api-bones-axios",
-  "version": "0.1.1",
+  "version": "4.4.0",
   "description": "Axios interceptor for transparent ApiResponse envelope stripping in Brefwiz SDKs",
   "author": "Brefwiz Team",
   "license": "MIT",

--- a/api-bones-progenitor/Cargo.toml
+++ b/api-bones-progenitor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api-bones-progenitor"
-version = "0.1.1"
+version = "4.4.0"
 edition = "2024"
 authors = ["Gregoire Salingue"]
 license = "MIT"

--- a/api-bones-reqwest/Cargo.toml
+++ b/api-bones-reqwest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api-bones-reqwest"
-version = "2.0.3"
+version = "4.4.0"
 edition = "2024"
 authors = ["Gregoire Salingue"]
 license = "MIT"
@@ -26,7 +26,7 @@ rust-version = "1.85"
 uuid = ["dep:uuid", "api-bones/uuid"]
 
 [dependencies]
-api-bones = { path = "..", version = "4.0", default-features = false, features = ["std", "serde"] }
+api-bones = { path = "..", version = "4.4", default-features = false, features = ["std", "serde"] }
 reqwest = { version = "0.13", default-features = false, features = ["json"] }
 uuid = { version = "1.23", optional = true }
 serde = { version = "1.0", features = ["derive"] }

--- a/api-bones-sdk-gen/CHANGELOG.md
+++ b/api-bones-sdk-gen/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to `api-bones-sdk-gen` are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [4.4.0] — 2026-04-25
+
+### Changed
+
+- Version aligned with the `api-bones` workspace (`4.4.0`). No functional changes.
+
 ## [0.2.0] — 2026-04-24
 
 ### Added

--- a/api-bones-sdk-gen/Cargo.toml
+++ b/api-bones-sdk-gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api-bones-sdk-gen"
-version = "0.2.0"
+version = "4.4.0"
 edition = "2024"
 authors = ["Gregoire Salingue"]
 license = "MIT"
@@ -12,7 +12,7 @@ name = "api-bones-sdk-gen"
 path = "src/main.rs"
 
 [dependencies]
-api-bones-progenitor = { path = "../api-bones-progenitor", version = "0.1" }
+api-bones-progenitor = { path = "../api-bones-progenitor", version = "4.4" }
 clap = { version = "4", features = ["derive"] }
 anyhow = "1"
 serde_json = "1"

--- a/api-bones-tower/Cargo.toml
+++ b/api-bones-tower/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api-bones-tower"
-version = "2.0.3"
+version = "4.4.0"
 edition = "2024"
 authors = ["Gregoire Salingue"]
 license = "MIT"
@@ -28,7 +28,7 @@ uuid = ["api-bones/uuid"]
 chrono = ["api-bones/chrono"]
 
 [dependencies]
-api-bones = { version = "4.0", path = "..", default-features = false, features = ["std", "serde"] }
+api-bones = { version = "4.4", path = "..", default-features = false, features = ["std", "serde"] }
 tower = { version = "0.5", features = ["util"] }
 http = { version = "1.0" }
 http-body = { version = "1.0" }


### PR DESCRIPTION
## Summary

- Bumps `api-bones` from `4.3.0` → `4.4.0`
- Aligns all satellite crates to `4.4.0`: `api-bones-tower` (was 2.0.3), `api-bones-reqwest` (was 2.0.3), `api-bones-progenitor` (was 0.1.1), `api-bones-sdk-gen` (was 0.2.0)
- Updates internal `version = "x.y"` constraints in each crate's `Cargo.toml`
- Adds `[4.4.0]` CHANGELOG entry covering the sdk-gen addition and version alignment

## Test plan

- `cargo check --workspace` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)