### PR TITLE
feat: add HasId trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-bones"
-version = "4.4.0"
+version = "4.5.0"
 dependencies = [
  "arbitrary",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "api-bones"
-version = "4.4.0"
+version = "4.5.0"
 edition = "2024"
 authors = ["Gregoire Salingue"]
 license = "MIT"

--- a/src/has_id.rs
+++ b/src/has_id.rs
@@ -1,0 +1,34 @@
+//! `HasId` — universal "this resource has an identifier" trait.
+//!
+//! Transport-agnostic. Lets helpers like `created_under` (in socle) compose
+//! a Location header from a route prefix + the resource's id without
+//! coupling DTOs to HTTP paths.
+
+use core::fmt::Display;
+
+pub trait HasId {
+    type Id: Display;
+    fn id(&self) -> &Self::Id;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct Thing {
+        id: u64,
+    }
+
+    impl HasId for Thing {
+        type Id = u64;
+        fn id(&self) -> &u64 {
+            &self.id
+        }
+    }
+
+    #[test]
+    fn id_is_displayable() {
+        let t = Thing { id: 42 };
+        assert_eq!(format!("{}", t.id()), "42");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,6 +147,9 @@ pub mod calendar;
 // OpenAPI helpers: Example<T> and DeprecatedField (issues #119, #120).
 pub mod openapi;
 
+pub mod has_id;
+pub use has_id::HasId;
+
 // Axum extractors beyond IntoResponse (issue #121).
 #[cfg(feature = "axum")]
 pub mod axum_extractors;


### PR DESCRIPTION
## Summary

- New `HasId` trait: `type Id: Display; fn id(&self) -> &Self::Id`
- Foundation for transport-agnostic helpers (e.g. socle's `created_under`)
  that compose a Location header from a route prefix + resource id.

## Test plan

- [x] Unit test asserts the bound is enforced and id formats via Display.

After merge: tag v4.5.0 and publish to the brefwiz registry per existing release process.