### PR TITLE
fix(release): add api-bones-test to crates publish list

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     with:
       # Publish in dependency order: api-bones must land on crates.io before
       # the satellite crates can resolve it.
-      crates: "api-bones api-bones-tower api-bones-reqwest api-bones-progenitor api-bones-sdk-gen"
+      crates: "api-bones api-bones-tower api-bones-reqwest api-bones-progenitor api-bones-sdk-gen api-bones-test"
     secrets:
       cargo-registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
     permissions:


### PR DESCRIPTION
## Summary

- `api-bones-test` was added to the workspace in `1aefd84` but never added to the `crates` list in `release.yml` — the release job silently skipped it
- Appended at the end of the publish list; order is correct since `api-bones` publishes first and `api-bones-test` depends on it

## Test plan

- [ ] Merge this PR
- [ ] Re-trigger the release (see below — no new version needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)