### PR TITLE
fix(api-bones-test): FakeOrgContext derives org_id from org_path.last()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.5.1] — 2026-04-25
+
+### Fixed
+
+- **`api-bones-test`**: `FakeOrgContext::for_principal` now derives `org_id` from `org_path.last()` (the acting / leaf org) instead of `org_path.first()` (the root). Passing a multi-level path previously produced a context where `org_id` was the root org, inconsistent with how `OrganizationContext` is used across the platform.
+
 ## [4.5.0] — 2026-04-25
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,7 +145,7 @@ dependencies = [
 
 [[package]]
 name = "api-bones-test"
-version = "4.5.0"
+version = "4.5.1"
 dependencies = [
  "api-bones",
  "async-nats",

--- a/api-bones-test/Cargo.toml
+++ b/api-bones-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api-bones-test"
-version = "4.5.0"
+version = "4.5.1"
 edition = "2024"
 authors = ["Gregoire Salingue"]
 license = "MIT"

--- a/api-bones-test/src/builders/org_context.rs
+++ b/api-bones-test/src/builders/org_context.rs
@@ -5,18 +5,23 @@ use api_bones::request_id::RequestId;
 
 /// Convenience shortcut for building a fake [`OrganizationContext`].
 ///
-/// Derives `org_id` from the first entry in `principal.org_path` (or generates
-/// a fresh one) so the context is internally consistent.
+/// Derives `org_id` from the **last** entry in `principal.org_path` (the
+/// acting / leaf org, per the Brefwiz `[root, …, leaf]` convention) or
+/// generates a fresh one when `org_path` is empty.
 ///
 /// # Quick start
 ///
 /// ```rust
 /// use uuid::Uuid;
 /// use api_bones_test::builders::{FakePrincipal, FakeOrgContext};
+/// use api_bones::org_id::OrgId;
 ///
-/// let p = FakePrincipal::user(Uuid::new_v4()).build();
+/// let leaf = OrgId::generate();
+/// let p = FakePrincipal::user(Uuid::new_v4())
+///     .org_path(vec![OrgId::generate(), leaf])
+///     .build();
 /// let ctx = FakeOrgContext::for_principal(&p);
-/// assert!(!ctx.org_id.to_string().is_empty());
+/// assert_eq!(ctx.org_id, leaf);
 /// ```
 pub struct FakeOrgContext;
 
@@ -25,7 +30,7 @@ impl FakeOrgContext {
     pub fn for_principal(principal: &Principal) -> OrganizationContext {
         let org_id = principal
             .org_path
-            .first()
+            .last()
             .copied()
             .unwrap_or_else(OrgId::generate);
         let org_path = principal.org_path.clone();


### PR DESCRIPTION
## Summary

- `FakeOrgContext::for_principal` was calling `.first()` on `org_path` to derive `org_id`
- The Brefwiz convention is `org_path = [root, …, leaf]` with `org_id` = the acting / leaf org
- `.first()` produced a context where `org_id == root`, silently inconsistent with any real `OrganizationContext`

## Test plan

- [x] Existing `api-bones-test` doctests pass with the corrected `.last()` call
- [x] New doctest in the doc-comment asserts `ctx.org_id == leaf` for a two-level path

🤖 Generated with [Claude Code](https://claude.com/claude-code)