### PR TITLE
chore(adr-0021): add pre-commit target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,3 +42,6 @@ ci-deny: ## CI: dependency license audit
 
 clean: ## Clean build artifacts
 	cargo clean
+
+.PHONY: pre-commit
+pre-commit: ci-format ci-lint ci-test ## Run all pre-commit checks (ADR-0021)


### PR DESCRIPTION
## Summary

Adds the `pre-commit` target required by ADR-0021 (Unified Makefile Contract for Brefwiz Repos):

```make
.PHONY: pre-commit
pre-commit: ci-format ci-lint ci-test ## Run all pre-commit checks (ADR-0021)
```

This brings the repo into compliance with the contract. All other required targets (`help`, `fmt`, `ci-format`, `ci-lint`, `ci-test`, `ci-coverage`) were already present.

## Why

Per ADR-0021, every brefwiz code repo must expose a uniform Makefile surface so CI workflows, local dev, and AI agent orchestration use one canonical command path per concern instead of language-native invocations. The CI guard added to `ci-workflows`/`shared-ci-workflows` will start enforcing this once merged.

## Test plan

- [ ] `make pre-commit` runs locally and exits 0 on a clean tree
- [ ] CI passes
