### PR TITLE
fix(response): use core::ops::Deref for no_std compatibility (4.5.1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "api-bones"
-version = "4.5.0"
+version = "4.5.1"
 edition = "2024"
 authors = ["Gregoire Salingue"]
 license = "MIT"

--- a/src/response.rs
+++ b/src/response.rs
@@ -226,7 +226,7 @@ impl proptest::arbitrary::Arbitrary for ResponseMeta {
 ///
 /// # Ergonomic access
 ///
-/// `ApiResponse<T>` implements [`Deref<Target = T>`](std::ops::Deref) so method
+/// `ApiResponse<T>` implements [`Deref<Target = T>`](core::ops::Deref) so method
 /// and field access on the payload works transparently without `.data`:
 ///
 /// ```rust
@@ -257,7 +257,7 @@ impl proptest::arbitrary::Arbitrary for ResponseMeta {
 /// let ApiResponse { data, meta, .. } = r;    // destructure
 /// ```
 ///
-/// [`DerefMut`](std::ops::DerefMut) is intentionally not implemented; mutate
+/// [`DerefMut`](core::ops::DerefMut) is intentionally not implemented; mutate
 /// after calling `into_inner()`.
 ///
 /// # Composing with `PaginatedResponse`
@@ -403,7 +403,7 @@ impl<T> ApiResponse<T> {
     }
 }
 
-impl<T> std::ops::Deref for ApiResponse<T> {
+impl<T> core::ops::Deref for ApiResponse<T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {


### PR DESCRIPTION
## Summary

Fixes a `no_std` build break in `api-bones` 4.5.0.

`response.rs:406` uses unconditional `std::ops::Deref` which fails when downstream consumers build with `default-features = false` (i.e. no_std + alloc). Two doc links at lines 229 and 260 had the same issue.

Replaces all `std::ops::*` references in `response.rs` with `core::ops::*`. `core` is always available regardless of std/no_std mode and provides identical traits.

## Reproduction

Reported by `sealwiz` and `distributed-ratelimit` builds:

```
error[E0433]: failed to resolve: use of unresolved module or unlinked crate `std`
   --> .../api-bones-4.5.0/src/response.rs:406:9
    |
406 | impl<T> std::ops::Deref for ApiResponse<T> {
    |         ^^^ use of unresolved module or unlinked crate `std`
```

Both repos consume `api-bones` with `default-features = false` (the documented no_std mode).

## Why this slipped through

The other `std::` uses in this crate (`vary.rs`, `etag.rs`, `cache.rs`, `range.rs`, `health.rs`, `error.rs`) are all correctly gated behind `#[cfg(feature = "std")]`. The Deref impl in `response.rs` was the lone unconditional reference — likely added without a no_std build verification.

Worth adding a `cargo check --no-default-features --features alloc` step to CI for this crate to prevent recurrence.

## Version

Bumps `Cargo.toml` 4.5.0 → 4.5.1 (patch — bugfix only, no API change).

## Test plan

- [ ] `cargo check --no-default-features --features alloc` passes
- [ ] `cargo check` (default features) still passes
- [ ] Downstream `sealwiz` and `distributed-ratelimit` build cleanly against the new version
