### PR TITLE
Potential fix for code scanning alert no. 29: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,8 @@ jobs:
     # Guard against publishing a version that doesn't match the tag.
     if: startsWith(github.ref, 'refs/tags/axios-v')
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
       - name: Verify axios-v<version> matches package.json


### PR DESCRIPTION
Potential fix for [https://github.com/brefwiz/api-bones/security/code-scanning/29](https://github.com/brefwiz/api-bones/security/code-scanning/29)

Add an explicit `permissions` block for the `validate-axios-tag` job in `.github/workflows/release.yml`.

Best minimal fix (without changing functionality):
- In job `validate-axios-tag`, set:
  - `contents: read` (required for `actions/checkout`).
- Place it alongside other job keys (`if`, `runs-on`, `steps`) so the job no longer inherits potentially broad defaults.

This preserves behavior and satisfies least privilege for that job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
