### PR TITLE
chore(adr-0021): add ci-changelog target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,4 +44,8 @@ clean: ## Clean build artifacts
 	cargo clean
 
 .PHONY: pre-commit
-pre-commit: ci-format ci-lint ci-test ## Run all pre-commit checks (ADR-0021)
+pre-commit: ci-format ci-lint ci-test ci-changelog ## Run all pre-commit checks (ADR-0021)
+
+.PHONY: ci-changelog
+ci-changelog: ## CI: verify CHANGELOG.md has entry for current package version (ADR-0021)
+	@bash <(curl -fsSL https://raw.githubusercontent.com/brefwiz/shared-ci-workflows/main/scripts/check-release-changelog.sh)


### PR DESCRIPTION
## Summary

Adds the `ci-changelog` Makefile target and chains it into `pre-commit`, per ADR-0021.

```make
.PHONY: ci-changelog
ci-changelog: ## CI: verify CHANGELOG.md has entry for current package version (ADR-0021)
	@bash <(curl -fsSL https://raw.githubusercontent.com/brefwiz/shared-ci-workflows/main/scripts/check-release-changelog.sh)

pre-commit: ci-format ci-lint ci-test ci-changelog ## …
```

## Why

Release pipelines fail post-merge with `Version X.Y.Z not found in CHANGELOG.md` when a manifest bump lands without a CHANGELOG entry. The `ci-changelog` target moves the gate to lint time AND local pre-commit. When `make pre-commit` runs, it verifies the current `Cargo.toml` (or `package.json` / `pyproject.toml`) version has a matching `## [VERSION]` heading in `CHANGELOG.md`.

Per ADR-0021 amendment ([brefwiz-architecture#18](https://git.brefwiz.com/brefwiz/brefwiz-architecture/pulls/18)) `ci-changelog` is part of the unified Makefile contract.

## Test plan

- [ ] `make ci-changelog` exits 0 when version matches
- [ ] `make pre-commit` runs the new step
