### PR TITLE
feat(borsh): add api-bones-borsh canonical codec crate (ADR platform/0047 Phase 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,9 +198,9 @@ dependencies = [
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c23f3af104b40a3430ccb90ed5f7bd877a8dc5c26fc92fde51a22b40890dcf9"
+checksum = "4ce73b17c62717c4b6a9af10b43e87c578b0cac27e00666d48304d3b7d2c0693"
 dependencies = [
  "filetime",
  "futures-core",
@@ -624,7 +624,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1004,7 +1004,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2063,15 +2063,14 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.78"
+version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
  "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -2095,9 +2094,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.114"
+version = "0.9.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
 dependencies = [
  "cc",
  "libc",
@@ -2752,7 +2751,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3293,7 +3292,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,6 +110,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "api-bones-borsh"
+version = "5.0.0"
+dependencies = [
+ "borsh",
+]
+
+[[package]]
 name = "api-bones-progenitor"
 version = "4.4.0"
 dependencies = [
@@ -505,6 +512,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
+dependencies = [
+ "borsh-derive",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -540,6 +570,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
@@ -624,7 +660,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1004,7 +1040,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2266,6 +2302,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro-error-attr2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2751,7 +2796,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3292,7 +3337,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3498,6 +3543,36 @@ dependencies = [
  "tokio-rustls",
  "tokio-util",
  "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+dependencies = [
+ "indexmap 2.14.0",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
 ]
 
 [[package]]
@@ -4242,6 +4317,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wiremock"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "api-bones-tower", "api-bones-reqwest", "api-bones-progenitor", "api-bones-sdk-gen", "api-bones-test"]
+members = [".", "api-bones-tower", "api-bones-reqwest", "api-bones-progenitor", "api-bones-sdk-gen", "api-bones-test", "api-bones-borsh"]
 resolver = "2"
 
 [workspace.lints.rust]

--- a/api-bones-borsh/Cargo.toml
+++ b/api-bones-borsh/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "api-bones-borsh"
+version = "5.0.0"
+edition = "2024"
+authors = ["Gregoire Salingue"]
+license = "MIT"
+description = "Canonical Borsh codec shim for chain-bound encoding (ADR platform/0047)"
+repository = "https://github.com/brefwiz/api-bones"
+homepage = "https://github.com/brefwiz/api-bones"
+documentation = "https://docs.rs/api-bones-borsh"
+keywords = ["borsh", "codec", "canonical", "chain", "encoding"]
+categories = ["encoding", "no-std"]
+rust-version = "1.85"
+
+[features]
+default = ["std"]
+## Enables `std::io::Error` in `BorshCanonicalError`. Without this, a minimal
+## enum is used instead (suitable for `no_std` + alloc environments).
+std = []
+
+[dependencies]
+borsh = { version = "1", default-features = false, features = ["derive"] }
+
+[lints.rust]
+unexpected_cfgs = { level = "allow", check-cfg = ['cfg(coverage)'] }
+unsafe_code = { level = "deny", priority = -1 }
+unsafe_op_in_unsafe_fn = { level = "deny", priority = -1 }
+warnings = { level = "deny", priority = -1 }
+unused_imports = { level = "deny", priority = -1 }
+unused_variables = { level = "deny", priority = -1 }
+dead_code = { level = "deny", priority = -1 }
+
+[lints.clippy]
+all = { level = "deny", priority = -1 }
+pedantic = { level = "deny", priority = -1 }
+nursery = { level = "warn", priority = -1 }
+missing_errors_doc = "allow"
+missing_panics_doc = "allow"
+module_name_repetitions = "allow"
+missing_const_for_fn = "allow"
+derive_partial_eq_without_eq = "allow"
+option_if_let_else = "allow"

--- a/api-bones-borsh/src/error.rs
+++ b/api-bones-borsh/src/error.rs
@@ -1,0 +1,32 @@
+//! Error type for canonical Borsh encoding operations.
+
+/// Error returned by [`crate::BorshCanonical::to_canonical_bytes`].
+#[derive(Debug)]
+pub struct BorshCanonicalError {
+    inner: borsh::io::Error,
+}
+
+impl BorshCanonicalError {
+    /// Construct from a [`borsh::io::Error`].
+    pub(crate) fn from_io(err: borsh::io::Error) -> Self {
+        Self { inner: err }
+    }
+
+    /// Return the underlying I/O error.
+    #[must_use]
+    pub fn io_error(&self) -> &borsh::io::Error {
+        &self.inner
+    }
+}
+
+impl core::fmt::Display for BorshCanonicalError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "borsh canonical encoding error: {}", self.inner)
+    }
+}
+
+#[cfg(feature = "std")]
+extern crate std;
+
+#[cfg(feature = "std")]
+impl std::error::Error for BorshCanonicalError {}

--- a/api-bones-borsh/src/lib.rs
+++ b/api-bones-borsh/src/lib.rs
@@ -1,0 +1,47 @@
+//! Canonical Borsh codec shim for chain-bound encoding (ADR platform/0047).
+//!
+//! Import [`prelude`] to get `BorshSerialize`, `BorshDeserialize`, and the
+//! encode/decode helpers without depending on `borsh` directly.
+#![no_std]
+#![deny(warnings, unsafe_code)]
+#![deny(missing_docs)]
+
+extern crate alloc;
+
+pub mod error;
+pub mod prelude;
+pub mod versioned;
+
+use alloc::vec::Vec;
+pub use borsh::{BorshDeserialize, BorshSerialize};
+
+pub use error::BorshCanonicalError;
+pub use versioned::VersionedBytes;
+
+/// Opinionated, version-tagged Borsh encoding contract.
+///
+/// Implementors pin [`CODEC_VERSION`](Self::CODEC_VERSION) to a `u8` constant.
+/// Any breaking change to the type's Borsh layout **must** increment this
+/// constant so consumers can detect version mismatches without inspecting raw
+/// bytes.
+pub trait BorshCanonical: BorshSerialize {
+    /// Monotonically increasing layout version.  Increment on every breaking
+    /// change to the Borsh field order or field set.
+    const CODEC_VERSION: u8;
+
+    /// Encode `self` into canonical Borsh bytes.
+    ///
+    /// The default implementation delegates to [`borsh::to_vec`].
+    fn to_canonical_bytes(&self) -> Result<Vec<u8>, BorshCanonicalError> {
+        borsh::to_vec(self).map_err(BorshCanonicalError::from_io)
+    }
+
+    /// Encode `self` into a [`VersionedBytes`] envelope tagging the bytes
+    /// with [`Self::CODEC_VERSION`].
+    fn to_versioned(&self) -> Result<VersionedBytes, BorshCanonicalError> {
+        Ok(VersionedBytes {
+            codec_version: Self::CODEC_VERSION,
+            bytes: self.to_canonical_bytes()?,
+        })
+    }
+}

--- a/api-bones-borsh/src/prelude.rs
+++ b/api-bones-borsh/src/prelude.rs
@@ -1,0 +1,7 @@
+//! Convenience re-exports — `use api_bones_borsh::prelude::*;` gives everything
+//! needed to implement and use canonical Borsh encoding without a direct `borsh`
+//! dependency in consumer crates.
+
+pub use borsh::{BorshDeserialize, BorshSerialize, from_slice, to_vec};
+
+pub use crate::{BorshCanonical, BorshCanonicalError, VersionedBytes};

--- a/api-bones-borsh/src/versioned.rs
+++ b/api-bones-borsh/src/versioned.rs
@@ -1,0 +1,18 @@
+//! Wire envelope for canonical Borsh bytes.
+
+use alloc::vec::Vec;
+use borsh::{BorshDeserialize, BorshSerialize};
+
+/// Wire envelope pairing a [`codec_version`](VersionedBytes::codec_version)
+/// tag with opaque canonical bytes.
+///
+/// The outer struct is itself Borsh-serialisable so it can be nested inside
+/// signed envelopes without an extra framing layer.
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub struct VersionedBytes {
+    /// Codec version declared by the originating type via
+    /// [`BorshCanonical::CODEC_VERSION`](crate::BorshCanonical::CODEC_VERSION).
+    pub codec_version: u8,
+    /// Canonical Borsh bytes of the inner payload.
+    pub bytes: Vec<u8>,
+}

--- a/api-bones-borsh/tests/determinism.rs
+++ b/api-bones-borsh/tests/determinism.rs
@@ -1,0 +1,99 @@
+//! Determinism snapshot tests for `api-bones-borsh` (ADR platform/0047).
+//!
+//! These tests verify:
+//! 1. `to_canonical_bytes()` is stable across repeated calls.
+//! 2. Output matches `borsh::to_vec()` directly.
+//! 3. A golden byte snapshot catches any Borsh-spec drift.
+
+use api_bones_borsh::prelude::*;
+
+/// Representative test payload covering the primitive types used by
+/// platform chain-bound types.
+#[derive(Debug, PartialEq, BorshSerialize, BorshDeserialize)]
+struct TestPayload {
+    schema_id: u32,
+    schema_version: u16,
+    value: u64,
+    label: String,
+    flags: Vec<bool>,
+}
+
+impl BorshCanonical for TestPayload {
+    const CODEC_VERSION: u8 = 1;
+}
+
+fn sample() -> TestPayload {
+    TestPayload {
+        schema_id: 42,
+        schema_version: 3,
+        value: 0xDEAD_BEEF_CAFE_1234,
+        label: "brefwiz".to_string(),
+        flags: vec![true, false, true],
+    }
+}
+
+#[test]
+fn canonical_bytes_are_stable() {
+    let p = sample();
+    let a = p.to_canonical_bytes().expect("first encode");
+    let b = p.to_canonical_bytes().expect("second encode");
+    assert_eq!(a, b, "to_canonical_bytes() must be deterministic");
+}
+
+#[test]
+fn canonical_bytes_match_borsh_to_vec() {
+    let p = sample();
+    let canonical = p.to_canonical_bytes().expect("canonical encode");
+    let direct = to_vec(&p).expect("borsh::to_vec");
+    assert_eq!(
+        canonical, direct,
+        "to_canonical_bytes() must equal borsh::to_vec() output"
+    );
+}
+
+#[test]
+fn golden_snapshot() {
+    let p = sample();
+    let bytes = p.to_canonical_bytes().expect("encode");
+
+    // Golden bytes for sample():
+    //   schema_id u32 LE=42, schema_version u16 LE=3,
+    //   value u64 LE=0xDEADBEEFCAFE1234,
+    //   label String (u32 len + utf8), flags Vec<bool> (u32 len + u8 each)
+    #[rustfmt::skip]
+    let expected: &[u8] = &[
+        0x2a, 0x00, 0x00, 0x00,                               // schema_id = 42
+        0x03, 0x00,                                            // schema_version = 3
+        0x34, 0x12, 0xfe, 0xca, 0xef, 0xbe, 0xad, 0xde,      // value
+        0x07, 0x00, 0x00, 0x00,                               // label len = 7
+        b'b', b'r', b'e', b'f', b'w', b'i', b'z',            // "brefwiz"
+        0x03, 0x00, 0x00, 0x00,                               // flags len = 3
+        0x01, 0x00, 0x01,                                     // [true, false, true]
+    ];
+
+    assert_eq!(
+        bytes.as_slice(),
+        expected,
+        "golden snapshot mismatch — Borsh spec may have drifted"
+    );
+}
+
+#[test]
+fn versioned_envelope_round_trips() {
+    let p = sample();
+    let versioned = p.to_versioned().expect("versioned encode");
+    assert_eq!(versioned.codec_version, TestPayload::CODEC_VERSION);
+
+    // VersionedBytes itself is Borsh-serialisable.
+    let outer = to_vec(&versioned).expect("outer encode");
+    let decoded: api_bones_borsh::VersionedBytes = from_slice(&outer).expect("outer decode");
+    assert_eq!(decoded, versioned);
+}
+
+#[test]
+fn round_trip_decode() {
+    let original = sample();
+    let bytes = original.to_canonical_bytes().expect("encode");
+    let decoded: TestPayload = from_slice(&bytes).expect("decode");
+    assert_eq!(original, decoded);
+}


### PR DESCRIPTION
## Summary

- Adds `api-bones-borsh` as a new workspace member implementing ADR platform/0047 Phase 1
- `BorshCanonical` trait: version-tagged encoding contract; default impl via `borsh::to_vec`
- `VersionedBytes` wire envelope: `(codec_version: u8, bytes: Vec<u8>)`, itself Borsh-serialisable for nested signed envelopes
- `BorshCanonicalError` wrapping `borsh::io::Error`; implements `std::error::Error` behind `std` feature
- `prelude` module: re-exports `BorshSerialize`, `BorshDeserialize`, `to_vec`, `from_slice` — consumers need no direct `borsh` dep
- `#![no_std]` compatible; `std` feature enables `std::error::Error` impl
- Determinism test harness (`tests/determinism.rs`): stability, match-borsh-to-vec, golden snapshot, round-trip, versioned-envelope tests

## Test plan

- [x] `make ci-format` — green
- [x] `make ci-lint` — green
- [x] `make ci-test` — green (all 5 determinism tests pass)

## Notes

Blocker for quorum substrate Borsh migration. Consumers import `api_bones_borsh::prelude::*` and implement `BorshCanonical` with a pinned `CODEC_VERSION` constant.
