### PR TITLE
feat(proto)!: bones.v1 canonical shapes + FilterOp lock + api-bones-protos crate

### DIFF
--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -1,0 +1,53 @@
+name: Proto
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  proto-lint:
+    name: Proto Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - name: Install buf
+        run: |
+          BIN="$HOME/.local/bin"
+          mkdir -p "$BIN"
+          VERSION="1.47.2"
+          curl -sSL \
+            "https://github.com/bufbuild/buf/releases/download/v${VERSION}/buf-$(uname -s)-$(uname -m)" \
+            -o "$BIN/buf"
+          chmod +x "$BIN/buf"
+          echo "$BIN" >> "$GITHUB_PATH"
+      - name: buf lint
+        run: make proto-lint
+
+  proto-breaking:
+    name: Proto Breaking Change
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install buf
+        run: |
+          BIN="$HOME/.local/bin"
+          mkdir -p "$BIN"
+          VERSION="1.47.2"
+          curl -sSL \
+            "https://github.com/bufbuild/buf/releases/download/v${VERSION}/buf-$(uname -s)-$(uname -m)" \
+            -o "$BIN/buf"
+          chmod +x "$BIN/buf"
+          echo "$BIN" >> "$GITHUB_PATH"
+      - name: buf breaking against origin/main
+        run: |
+          git fetch origin main
+          make proto-breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.0.0] — 2026-05-16
+
+### Breaking
+
+- **`FilterEntry.operator: String` → `FilterEntry.op: FilterOp`** (`src/query.rs`). The Rust crate now matches the proto-side discipline (`bones.v1.FilterOp` in `proto/bones/v1/queries.proto`) — operator is a closed enum, not a free string. Per-service operator dialects ("eq" vs "equal" vs "==") can no longer drift.
+
+  Migration:
+  ```rust
+  // 5.x:
+  FilterEntry::new("status", "eq", "active")
+  entry.operator == "eq"
+
+  // 6.0:
+  use api_bones::FilterOp;
+  FilterEntry::new("status", FilterOp::Eq, "active")
+  entry.op == FilterOp::Eq
+  ```
+
+  JSON field name also changes: `operator` → `op`. Downstream consumers serializing `FilterParams` need to update their persisted documents / API contracts. `FilterOp` serializes as snake_case (`eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `in`, `not_in`, `contains`, `starts_with`, `ends_with`, `exists`, `not_exists`).
+
+### Added
+
+- **`FilterOp` enum** re-exported from the crate root. 13 variants covering eq/neq, ordered comparisons (gt/gte/lt/lte), membership (in/not_in), substring matching (contains/starts_with/ends_with), and presence checks (exists/not_exists).
+- **`proto/bones/v1/queries.proto`** — canonical proto shapes for sort + filter + search. Mirror of the Rust types, with `FilterOp` as a closed proto enum. Companion to the earlier `pagination.proto`, `errors.proto`, and `ratelimit.proto` shapes.
+
 ## [5.0.0] — 2026-04-30
 
 ### Breaking

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-bones"
-version = "5.0.0"
+version = "6.0.0"
 dependencies = [
  "arbitrary",
  "axum",
@@ -118,6 +118,10 @@ dependencies = [
  "progenitor",
  "serde_json",
 ]
+
+[[package]]
+name = "api-bones-protos"
+version = "0.1.0"
 
 [[package]]
 name = "api-bones-reqwest"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,13 @@
 [workspace]
-members = [".", "api-bones-tower", "api-bones-reqwest", "api-bones-progenitor", "api-bones-sdk-gen", "api-bones-test"]
+members = [
+    ".",
+    "api-bones-tower",
+    "api-bones-reqwest",
+    "api-bones-progenitor",
+    "api-bones-sdk-gen",
+    "api-bones-test",
+    "api-bones-protos",
+]
 resolver = "2"
 
 [workspace.lints.rust]
@@ -12,7 +20,7 @@ pedantic = { level = "deny", priority = -1 }
 
 [package]
 name = "api-bones"
-version = "5.0.0"
+version = "6.0.0"
 edition = "2024"
 authors = ["Gregoire Salingue"]
 license = "MIT"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # Makefile for api-bones
 
-.PHONY: help fmt ci-format ci-lint ci-no-std ci-test ci-coverage ci-audit ci-deny build clean
+.PHONY: help fmt ci-format ci-lint ci-no-std ci-test ci-coverage ci-audit ci-deny build clean \
+	proto-lint proto-breaking
 
 .DEFAULT_GOAL := help
 
@@ -42,6 +43,18 @@ ci-deny: ## CI: dependency license audit
 
 clean: ## Clean build artifacts
 	cargo clean
+
+# ─── Canonical proto shapes ──────────────────────────────────────────────────
+
+proto-lint: ## Lint proto/bones/v1/*.proto with buf
+	buf lint proto
+
+proto-breaking: ## Check proto/ for breaking changes vs origin/main
+	@if git cat-file -e origin/main:proto/buf.yaml 2>/dev/null; then \
+		buf breaking proto --against ".git#branch=origin/main,subdir=proto"; \
+	else \
+		echo "proto/ not present on origin/main yet — skipping breaking-change check"; \
+	fi
 
 .PHONY: pre-commit
 pre-commit: ci-format ci-lint ci-test ci-changelog ## Run all pre-commit checks (ADR-0021)

--- a/api-bones-protos/Cargo.toml
+++ b/api-bones-protos/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "api-bones-protos"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.88"
+authors = ["Gregoire Salingue"]
+license = "MIT"
+description = "Embedded bytes of the api-bones canonical proto shapes (bones/v1/*.proto). Pair with `proto-build-kit` to stage on the protoc include path at build time."
+repository = "https://github.com/brefwiz/api-bones"
+homepage = "https://github.com/brefwiz/api-bones"
+documentation = "https://docs.rs/api-bones-protos"
+readme = "README.md"
+keywords = ["protobuf", "buf", "tonic", "connectrpc", "build-script"]
+categories = ["development-tools::build-utils"]
+# Embed the .proto sources in the published .crate tarball.
+include = ["src/**/*.rs", "../proto/bones/v1/*.proto", "README.md", "LICENSE"]
+
+[lints]
+workspace = true
+
+[lib]
+path = "src/lib.rs"
+
+# Zero runtime dependencies — this crate just exposes raw bytes.
+[dependencies]

--- a/api-bones-protos/LICENSE
+++ b/api-bones-protos/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Grégoire Salingue
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/api-bones-protos/README.md
+++ b/api-bones-protos/README.md
@@ -1,0 +1,50 @@
+# api-bones-protos
+
+[![crates.io](https://img.shields.io/crates/v/api-bones-protos.svg)](https://crates.io/crates/api-bones-protos)
+[![docs.rs](https://img.shields.io/docsrs/api-bones-protos)](https://docs.rs/api-bones-protos)
+
+Embedded bytes of the canonical proto shapes shipped by the
+[`api-bones`](https://crates.io/crates/api-bones) crate ecosystem
+(`bones/v1/*.proto`).
+
+**Zero runtime dependencies.** This crate exists purely as a
+distribution mechanism for the proto bytes. Pair it with a staging
+library (e.g.
+[`proto-build-kit`](https://crates.io/crates/proto-build-kit)) to
+write the bytes to a tempdir at protoc-relative paths at consumer
+build time:
+
+```rust,no_run
+use proto_build_kit::Stager;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let staged = Stager::new()
+        .with(api_bones_protos::files())
+        .stage()?;
+
+    // Add staged.path() to your codegen include path:
+    connectrpc_build::Config::new()
+        .files(&["proto/my/v1/svc.proto"])
+        .includes(&["proto/", staged.path()])
+        .include_file("_connectrpc.rs")
+        .compile()?;
+    Ok(())
+}
+```
+
+## What's included
+
+| File                              | Messages |
+|-----------------------------------|----------|
+| `bones/v1/pagination.proto`       | `PageRequest`, `PageResponse`, `OffsetPageRequest`, `OffsetPageResponse` |
+| `bones/v1/queries.proto`          | `SortDirection`, `SortField`, `SortParams`, `FilterOp`, `FilterEntry`, `FilterParams`, `SearchParams` |
+| `bones/v1/errors.proto`           | `ValidationFailure` |
+| `bones/v1/ratelimit.proto`        | `RateLimitInfo` |
+
+See `proto/README.md` in the api-bones repo for the canonical
+schema inventory and the per-message Rust counterparts in the
+`api-bones` crate.
+
+## License
+
+MIT.

--- a/api-bones-protos/src/lib.rs
+++ b/api-bones-protos/src/lib.rs
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: MIT
+//! Embedded bytes of the api-bones canonical proto shapes.
+//!
+//! This crate ships the `bones/v1/*.proto` files via `include_bytes!`
+//! and exposes a single accessor — [`files`] — that yields
+//! `(relative_path, bytes)` pairs ready for staging onto a protoc
+//! include path at consumer build time.
+//!
+//! **Zero runtime dependencies.** This crate exists purely as a
+//! distribution mechanism for the bytes. Pair it with any staging
+//! library (e.g. [`proto-build-kit`](https://crates.io/crates/proto-build-kit))
+//! to assemble a tempdir for codegen tools (connectrpc-build,
+//! tonic-prost-build, ...).
+//!
+//! # Example
+//!
+//! ```no_run
+//! # // We can't actually run this in a doctest because it depends on
+//! # // proto-build-kit, but it shows the shape.
+//! # mod proto_build_kit {
+//! #     pub struct Stager;
+//! #     impl Stager {
+//! #         pub fn new() -> Self { Self }
+//! #         pub fn with<I>(self, _: I) -> Self { self }
+//! #         pub fn stage(self) -> Result<tempfile::TempDir, std::io::Error> {
+//! #             tempfile::tempdir()
+//! #         }
+//! #     }
+//! # }
+//! let staged = proto_build_kit::Stager::new()
+//!     .with(api_bones_protos::files())
+//!     .stage()
+//!     .expect("stage");
+//! // Add staged.path() to your protoc include path.
+//! ```
+//!
+//! # What's included
+//!
+//! The shapes match the proto/bones/v1/ directory in the api-bones
+//! repo. See the README for the canonical schema inventory.
+
+const PAGINATION_PROTO: &[u8] = include_bytes!("../../proto/bones/v1/pagination.proto");
+const QUERIES_PROTO: &[u8] = include_bytes!("../../proto/bones/v1/queries.proto");
+const ERRORS_PROTO: &[u8] = include_bytes!("../../proto/bones/v1/errors.proto");
+const RATELIMIT_PROTO: &[u8] = include_bytes!("../../proto/bones/v1/ratelimit.proto");
+
+/// Yield `(relative_path, bytes)` pairs for every `bones/v1/*.proto`
+/// file shipped by this crate.
+///
+/// `relative_path` is the protoc-style import path consumers use
+/// (`bones/v1/pagination.proto`, etc.). The order of the iterator is
+/// stable but unspecified — consumers should not rely on it.
+pub fn files() -> impl Iterator<Item = (&'static str, &'static [u8])> {
+    [
+        ("bones/v1/pagination.proto", PAGINATION_PROTO),
+        ("bones/v1/queries.proto", QUERIES_PROTO),
+        ("bones/v1/errors.proto", ERRORS_PROTO),
+        ("bones/v1/ratelimit.proto", RATELIMIT_PROTO),
+    ]
+    .into_iter()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ships_four_files() {
+        let v: Vec<_> = files().collect();
+        assert_eq!(v.len(), 4);
+    }
+
+    #[test]
+    fn relative_paths_are_unique() {
+        let mut paths: Vec<_> = files().map(|(p, _)| p).collect();
+        let n = paths.len();
+        paths.sort_unstable();
+        paths.dedup();
+        assert_eq!(paths.len(), n, "duplicate relative paths in files()");
+    }
+
+    #[test]
+    fn every_file_has_non_empty_bytes() {
+        for (path, bytes) in files() {
+            assert!(!bytes.is_empty(), "{path} embeds empty bytes");
+        }
+    }
+
+    #[test]
+    fn pagination_proto_declares_expected_messages() {
+        let body = std::str::from_utf8(PAGINATION_PROTO).expect("utf8");
+        for msg in [
+            "message PageRequest",
+            "message PageResponse",
+            "message OffsetPageRequest",
+            "message OffsetPageResponse",
+        ] {
+            assert!(body.contains(msg), "pagination.proto missing `{msg}`");
+        }
+    }
+
+    #[test]
+    fn queries_proto_declares_filter_op_enum() {
+        let body = std::str::from_utf8(QUERIES_PROTO).expect("utf8");
+        assert!(
+            body.contains("enum FilterOp"),
+            "queries.proto missing FilterOp enum"
+        );
+        assert!(
+            body.contains("FILTER_OP_EQ"),
+            "queries.proto missing FILTER_OP_EQ"
+        );
+    }
+}

--- a/api-bones-reqwest/Cargo.toml
+++ b/api-bones-reqwest/Cargo.toml
@@ -26,7 +26,7 @@ rust-version = "1.85"
 uuid = ["dep:uuid", "api-bones/uuid"]
 
 [dependencies]
-api-bones = { path = "..", version = "5.0", default-features = false, features = ["std", "serde"] }
+api-bones = { path = "..", version = "6.0", default-features = false, features = ["std", "serde"] }
 reqwest = { version = "0.13", default-features = false, features = ["json"] }
 uuid = { version = "1.23", optional = true }
 serde = { version = "1.0", features = ["derive"] }

--- a/api-bones-test/Cargo.toml
+++ b/api-bones-test/Cargo.toml
@@ -38,7 +38,7 @@ nats = [
 ]
 
 [dependencies]
-api-bones = { path = "..", version = "5.0", features = ["chrono", "uuid", "serde", "std"] }
+api-bones = { path = "..", version = "6.0", features = ["chrono", "uuid", "serde", "std"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 uuid = { version = "1.23", features = ["v4"] }
@@ -64,7 +64,7 @@ testcontainers = { version = "0.27", optional = true }
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 serde_json = "1.0"
-api-bones = { path = "..", version = "5.0", features = ["chrono", "uuid", "serde", "std", "axum"] }
+api-bones = { path = "..", version = "6.0", features = ["chrono", "uuid", "serde", "std", "axum"] }
 
 [lints.rust]
 unexpected_cfgs = { level = "allow", check-cfg = ['cfg(coverage)'] }

--- a/api-bones-tower/Cargo.toml
+++ b/api-bones-tower/Cargo.toml
@@ -28,7 +28,7 @@ uuid = ["api-bones/uuid"]
 chrono = ["api-bones/chrono"]
 
 [dependencies]
-api-bones = { version = "5.0", path = "..", default-features = false, features = ["std", "serde"] }
+api-bones = { version = "6.0", path = "..", default-features = false, features = ["std", "serde"] }
 tower = { version = "0.5", features = ["util"] }
 http = { version = "1.0" }
 http-body = { version = "1.0" }

--- a/examples/query_params.rs
+++ b/examples/query_params.rs
@@ -5,7 +5,7 @@
 //!
 //! Run: `cargo run --example query_params`
 
-use api_bones::{FilterEntry, FilterParams, SearchParams, SortDirection, SortParams};
+use api_bones::{FilterEntry, FilterOp, FilterParams, SearchParams, SortDirection, SortParams};
 
 fn main() {
     // -- Sorting --
@@ -27,12 +27,12 @@ fn main() {
     let filters = FilterParams::new(vec![
         FilterEntry {
             field: "status".into(),
-            operator: "eq".into(),
+            op: FilterOp::Eq,
             value: "active".into(),
         },
         FilterEntry {
             field: "price".into(),
-            operator: "gt".into(),
+            op: FilterOp::Gt,
             value: "100".into(),
         },
     ]);

--- a/proto/README.md
+++ b/proto/README.md
@@ -1,0 +1,113 @@
+# `api-bones/proto/` — canonical proto shapes
+
+Companion to the `api-bones` Rust crate. The Rust crate (`./src/`) ships
+canonical types for the utoipa-derived HTTP+JSON wire surface; this
+directory ships canonical `.proto` shapes for the proto-source wire
+surface (gRPC, gRPC-Web, and Connect-protocol HTTP+JSON).
+
+## Layout
+
+```
+proto/
+├── buf.yaml               # lint + breaking-change rules
+├── README.md
+└── bones/v1/
+    ├── pagination.proto   # PageRequest, PageResponse (cursor-based)
+    │                      # OffsetPageRequest, OffsetPageResponse (offset/limit)
+    ├── queries.proto      # SortDirection, SortField, SortParams
+    │                      # FilterOp, FilterEntry, FilterParams
+    │                      # SearchParams
+    ├── errors.proto       # ValidationFailure
+    └── ratelimit.proto    # RateLimitInfo
+```
+
+Versioning lives in the proto package name (`bones.v1`, `bones.v2`, ...).
+Field-number additions are backward-compatible; renames / deletions are not
+— bump the package major and run a parallel-window migration.
+
+## Shape inventory + Rust counterparts
+
+| Proto type                    | Rust counterpart                              | Notes |
+|-------------------------------|-----------------------------------------------|-------|
+| `bones.v1.PageRequest`        | `api_bones::CursorPaginationParams`           | Cursor-based (AIP-158, default for new APIs). |
+| `bones.v1.PageResponse`       | `api_bones::CursorPagination` + revision      | `revision` doubles as list-level ETag. |
+| `bones.v1.OffsetPageRequest`  | `api_bones::PaginationParams`                 | Offset/limit (admin UIs, small datasets). |
+| `bones.v1.OffsetPageResponse` | `api_bones::PaginatedResponse<T>` envelope    | Total count + has_more. |
+| `bones.v1.SortDirection`      | `api_bones::query::SortDirection`             | Asc/Desc enum. |
+| `bones.v1.SortField`          | `api_bones::query::SortParams` (single field) | Per-field sort directive. |
+| `bones.v1.SortParams`         | `api_bones::query::SortParams` (multi-field)  | Composes `SortField`s for multi-key sort. |
+| `bones.v1.FilterOp`           | (proto-side discipline)                       | Closed enum — services MUST NOT accept off-list operators. The Rust counterpart keeps `operator` as a free string; proto locks it down. |
+| `bones.v1.FilterEntry`        | `api_bones::query::FilterEntry`               | Field/op/value triple. |
+| `bones.v1.FilterParams`       | `api_bones::query::FilterParams`              | AND-combined filter set. |
+| `bones.v1.SearchParams`       | `api_bones::query::SearchParams`              | Free-text search with optional field scoping. |
+| `bones.v1.ValidationFailure`  | `api_bones::error::ValidationError`           | Connect error detail; one per failing field. |
+| `bones.v1.RateLimitInfo`      | `api_bones::ratelimit::RateLimitInfo`         | Typed response metadata (gRPC trailer / Connect response header). |
+
+## How services consume these
+
+Services import the shapes by package name:
+
+```proto
+syntax = "proto3";
+package myservice.v1;
+
+import "bones/v1/pagination.proto";
+import "bones/v1/errors.proto";
+
+message ListFoosRequest {
+  bones.v1.PageRequest page = 1;
+  // ...service-specific filters
+}
+message ListFoosResponse {
+  repeated Foo items = 1;
+  bones.v1.PageResponse page = 2;
+}
+```
+
+Distribution to the consuming repo is the consumer's choice (git
+submodule of this repo, buf module dependency once published to a
+registry, vendored copies). Generated Rust / TS / Go bindings live
+inside each consuming codebase — these `.proto` files are the source,
+the bindings are downstream artifacts.
+
+## Shapes deliberately NOT in `bones.v1`
+
+The audit of the api-bones Rust surface against the bar "canonical AND a
+wire shape" produced this skip list. Documented so future contributors
+don't redo the audit:
+
+| Rust type | Why no proto equivalent |
+|---|---|
+| `ApiResponse<T>`, `ResponseMeta`, `ApiError`, `ProblemJson` | Connect protocol ships its own response/error envelope; the proto wire shape doesn't redefine it. |
+| `Link`, `Links` (HATEOAS) | Proto-source services navigate via RPC, not URLs. |
+| `ETag`, `IfMatch`, `IfNoneMatch` | Just `string` on the proto wire; envelope semantics are usually annotation-driven on the response field rather than typed wrappers. |
+| `IdempotencyKey`, `Cursor`, `Slug`, `OrgId`, `CorrelationId`, `RequestId` | Strong-typed Rust wrappers around `string`/`uuid`; proto uses the primitive directly. |
+| `CacheControl`, `Vary`, `ContentType`, `HttpMethod`, `StatusCode`, `RangeHeader`, `ContentRange`, `ByteRange`, `HeaderName`, `HeaderValue`, `CorsOrigin`, `CorsHeaders` | HTTP-layer concerns. Proto/gRPC uses metadata, different model. |
+| `HealthStatus`, `HealthCheck`, `LivenessResponse`, `ReadinessResponse` | Standardized by `grpc.health.v1` — services use `tonic-health` directly. |
+| `BulkRequest<T>`, `BulkResponse<T>`, `BulkItemResult<T>` | Generics don't translate cleanly to proto. Bulk operations in proto-land model as streaming RPCs (per-item progress) rather than request/response with item arrays. Add per-service if needed. |
+| `Deprecated`, `Example<T>`, `DeprecatedField` | utoipa/OpenAPI metadata helpers. Proto has its own field/method deprecation mechanism. |
+| `Principal`, `PrincipalId`, `AuditInfo`, `ResolvedPrincipal`, `DeviceLease` | Server-side audit context types, not wire shapes. |
+| `ApiVersion`, `SemverTriple` | Version strings — proto package version naming (`bones.v1`) is the canonical mechanism. |
+| `TraceContext`, `TraceId`, `SpanId`, `SamplingFlags` | W3C Trace Context is standardized elsewhere; OpenTelemetry's proto definitions cover this. |
+| `UrlBuilder`, `QueryBuilder`, `RetryPolicy`, `BackoffStrategy`, `RetryAfter` | Client-side helpers, never on the wire. |
+| `ApiErrorBuilder`, `ApiResponseBuilder`, `HealthCheckBuilder`, `ReadinessResponseBuilder` | Rust builder types. |
+
+If a service genuinely needs a canonical type from the skip list, add it
+with a brief rationale here and a PR to bump the version.
+
+## When to add a new shape
+
+A new `bones.v1.*` message gets added when it would otherwise be
+**duplicated verbatim** across two or more services. The bar:
+
+1. Identical field shape + semantics across services (not just similar).
+2. Cross-service SDK consumers benefit from one type instead of N.
+3. Versioning discipline is maintainable (proto3 backward-compat rules apply).
+
+If the shape varies per service, it doesn't belong here.
+
+## CI
+
+`make proto-lint` runs `buf lint`; `make proto-breaking` runs `buf
+breaking` against `origin/main`. Both are gated in
+`.github/workflows/proto.yml`.

--- a/proto/bones/v1/errors.proto
+++ b/proto/bones/v1/errors.proto
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: LicenseRef-Proprietary
+//
+// Canonical error-detail shapes — the proto-side companion to
+// `api_bones::error::ValidationError`.
+//
+// Connect protocol ships its own top-level error envelope
+// (`{ code, message, details }`) — we do NOT redefine it here. What
+// IS canonical: the typed error-detail messages that services attach
+// to that envelope under `details`. `ValidationFailure` is the first;
+// more land as consumers need them.
+//
+// Usage on the wire (Connect HTTP+JSON):
+//
+//   HTTP/1.1 400 Bad Request
+//   Content-Type: application/json
+//   {
+//     "code": "invalid_argument",
+//     "message": "request did not validate",
+//     "details": [{
+//       "@type": "type.googleapis.com/bones.v1.ValidationFailure",
+//       "field": "/email",
+//       "message": "must be a valid email address",
+//       "rule": "format"
+//     }]
+//   }
+
+syntax = "proto3";
+
+package bones.v1;
+
+// A single field-level validation failure. Composed by services into a
+// Connect error envelope under `details` (one `ValidationFailure` per
+// failing field). Server-side request-validators typically emit one of
+// these per `validator`-style rule that fires on a request body.
+message ValidationFailure {
+  // JSON Pointer to the offending field (RFC 6901), e.g. `/email`
+  // or `/items/0/quantity`. Empty string for top-level failures.
+  string field = 1;
+
+  // Human-readable description of what went wrong.
+  string message = 2;
+
+  // Optional machine-readable rule identifier (e.g. `min_length`,
+  // `format`, `range`). Empty when the failure doesn't map to a
+  // discrete rule.
+  string rule = 3;
+}

--- a/proto/bones/v1/pagination.proto
+++ b/proto/bones/v1/pagination.proto
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: LicenseRef-Proprietary
+//
+// Canonical pagination shapes — the proto-side companion to
+// `api_bones::pagination::*` Rust types.
+//
+// Two contracts, mirroring the Rust crate's two pagination flavors:
+//
+//   - Cursor-based (default for new APIs, AIP-158): opaque cursor +
+//     page_size. Stable iteration under inserts. No random access.
+//     Mirrors `api_bones::pagination::CursorPaginationParams` /
+//     `CursorPagination`.
+//
+//   - Offset/limit (admin tools, small datasets): offset + limit +
+//     total_count + has_more. Random page access. Pages can shift
+//     under inserts. Mirrors `api_bones::pagination::PaginationParams`
+//     / `PaginatedResponse`.
+//
+// Use cursor-based by default. Use offset/limit when random access
+// or total_count is a hard requirement.
+
+syntax = "proto3";
+
+package bones.v1;
+
+// =============================================================================
+// Cursor-based pagination (AIP-158, default)
+// =============================================================================
+
+// Cursor-based pagination request. Empty cursor = start; page_size 0 = server default.
+//
+//   message ListFoosRequest {
+//     bones.v1.PageRequest page = 1;
+//   }
+message PageRequest {
+  // Opaque cursor returned by a previous PageResponse.next_cursor.
+  // Empty string means start of collection.
+  string cursor = 1;
+
+  // Max items the server should return on this page.
+  // 0 means use the server default.
+  uint32 page_size = 2;
+}
+
+// Cursor-based pagination response. Empty next_cursor = no more pages.
+// `revision` doubles as the list-level ETag for cache validation.
+//
+//   message ListFoosResponse {
+//     repeated Foo items = 1;
+//     bones.v1.PageResponse page = 2;
+//   }
+message PageResponse {
+  // Opaque cursor for the next page. Empty when no more pages.
+  string next_cursor = 1;
+
+  // Collection-level revision/ETag — increments on any mutation.
+  // Used for list-level cache validation via if-none-match metadata.
+  string revision = 2;
+}
+
+// =============================================================================
+// Offset/limit pagination (admin tools, small datasets)
+// =============================================================================
+
+// Offset/limit pagination request.
+//
+// Defaults track the Rust crate's `PaginationParams::default()`:
+// limit = 20 (when 0), offset = 0.
+//
+//   message ListUsersRequest {
+//     bones.v1.OffsetPageRequest page = 1;
+//   }
+message OffsetPageRequest {
+  // Max items the server should return on this page.
+  // 0 means use the server default (20).
+  uint64 limit = 1;
+
+  // Number of items to skip before this page.
+  uint64 offset = 2;
+}
+
+// Offset/limit pagination response.
+//
+//   message ListUsersResponse {
+//     repeated User items = 1;
+//     bones.v1.OffsetPageResponse page = 2;
+//   }
+message OffsetPageResponse {
+  // Total number of items across all pages.
+  uint64 total_count = 1;
+
+  // Whether more items exist beyond this page.
+  bool has_more = 2;
+
+  // Max items per page (echoes the requested or default limit).
+  uint64 limit = 3;
+
+  // Number of items skipped before this page.
+  uint64 offset = 4;
+}

--- a/proto/bones/v1/queries.proto
+++ b/proto/bones/v1/queries.proto
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: LicenseRef-Proprietary
+//
+// Canonical query parameter shapes — the proto-side companion to
+// `api_bones::query::{SortDirection, SortParams, FilterEntry,
+// FilterParams, SearchParams}`.
+//
+// Locked-in shape: list endpoints across services consume these
+// messages directly. Per-service operator dialects ("eq" vs "equal"
+// vs "==") are rejected — the `FilterOp` enum is the contract.
+
+syntax = "proto3";
+
+package bones.v1;
+
+// =============================================================================
+// Sorting
+// =============================================================================
+
+// Sort order. UNSPECIFIED defaults to ASC server-side.
+enum SortDirection {
+  SORT_DIRECTION_UNSPECIFIED = 0;
+  SORT_DIRECTION_ASC = 1;
+  SORT_DIRECTION_DESC = 2;
+}
+
+// Per-field sort directive. Composes into `SortParams` for multi-field
+// sort; a single `SortParams` is the common case.
+message SortField {
+  // Field name to sort by (e.g. "created_at", "name"). Service-specific
+  // allowed-field list is enforced server-side.
+  string field = 1;
+
+  // Sort direction.
+  SortDirection direction = 2;
+}
+
+// Sort parameters for a list endpoint. Empty `fields` means server
+// default order.
+message SortParams {
+  repeated SortField fields = 1;
+}
+
+// =============================================================================
+// Filtering
+// =============================================================================
+
+// Filter comparison operator. Closed enum — services MUST NOT accept
+// off-list operators on the wire; per-service handlers may reject the
+// subset they don't implement, but the wire vocabulary is fixed here.
+enum FilterOp {
+  FILTER_OP_UNSPECIFIED = 0;
+
+  // Equality / inequality.
+  FILTER_OP_EQ = 1;
+  FILTER_OP_NEQ = 2;
+
+  // Ordered comparisons (numeric, timestamp, lexical).
+  FILTER_OP_GT = 3;
+  FILTER_OP_GTE = 4;
+  FILTER_OP_LT = 5;
+  FILTER_OP_LTE = 6;
+
+  // Membership; `value` carries a server-defined separator (default ',').
+  FILTER_OP_IN = 7;
+  FILTER_OP_NOT_IN = 8;
+
+  // Substring / prefix / suffix matching on string fields.
+  FILTER_OP_CONTAINS = 9;
+  FILTER_OP_STARTS_WITH = 10;
+  FILTER_OP_ENDS_WITH = 11;
+
+  // Presence / absence (`value` ignored).
+  FILTER_OP_EXISTS = 12;
+  FILTER_OP_NOT_EXISTS = 13;
+}
+
+// A single field/op/value triple.
+message FilterEntry {
+  // Field name being filtered. Service-specific allowed-field list
+  // is enforced server-side.
+  string field = 1;
+
+  // Operator. UNSPECIFIED is rejected by handlers; clients MUST set
+  // an explicit op.
+  FilterOp op = 2;
+
+  // Comparison value. Always a string on the wire — handlers parse
+  // per-field type (number, bool, timestamp, ...). For IN / NOT_IN
+  // the value is a separator-joined list (default separator: ',').
+  // For EXISTS / NOT_EXISTS the value is ignored.
+  string value = 3;
+}
+
+// AND-combined filter set. Empty `entries` means no filtering.
+// OR semantics, if needed, are handled per-service via dedicated
+// fields on the request message (not via this canonical shape).
+message FilterParams {
+  repeated FilterEntry entries = 1;
+}
+
+// =============================================================================
+// Free-text search
+// =============================================================================
+
+// Search parameters for full-text list endpoints. Empty `query` means
+// no search (treat as a plain list); empty `fields` means search the
+// service's default field set.
+message SearchParams {
+  // Search query string. Service-specific length cap enforced
+  // server-side; api-bones Rust counterpart caps at 500 chars.
+  string query = 1;
+
+  // Optional list of field names to scope the search to. Empty =
+  // server default fields.
+  repeated string fields = 2;
+}

--- a/proto/bones/v1/ratelimit.proto
+++ b/proto/bones/v1/ratelimit.proto
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: LicenseRef-Proprietary
+//
+// Canonical rate-limit metadata — the proto-side companion to
+// `api_bones::ratelimit::RateLimitInfo` (the X-RateLimit-* header
+// set on the HTTP+JSON surface).
+//
+// On the proto/Connect/gRPC surface, services attach `RateLimitInfo`
+// as response metadata (gRPC trailer / Connect response header in
+// a future-proof typed form) instead of stringly-typed headers.
+//
+// On 429 responses (Connect code `resource_exhausted`), services
+// SHOULD populate `retry_after` so clients can back off correctly.
+
+syntax = "proto3";
+
+package bones.v1;
+
+// Rate-limit metadata returned alongside a response.
+message RateLimitInfo {
+  // Maximum number of requests allowed in the current window.
+  uint64 limit = 1;
+
+  // Number of requests remaining in the current window.
+  uint64 remaining = 2;
+
+  // Unix timestamp (seconds) at which the current window resets.
+  uint64 reset = 3;
+
+  // Seconds the client should wait before retrying. Set on
+  // resource_exhausted (HTTP 429) responses; 0 when not applicable.
+  uint64 retry_after = 4;
+}

--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -1,0 +1,14 @@
+version: v2
+modules:
+  - path: .
+lint:
+  use:
+    - STANDARD
+  except:
+    # `bones.v1` is the package name; no per-file suffix needed beyond
+    # the version. buf's default expects message suffixes like `_v1` —
+    # we use the established `bones.v1.Message` convention instead.
+    - PACKAGE_VERSION_SUFFIX
+breaking:
+  use:
+    - FILE

--- a/src/fake_impls.rs
+++ b/src/fake_impls.rs
@@ -391,10 +391,20 @@ impl Dummy<Faker> for crate::query::SortParams {
 
 impl Dummy<Faker> for crate::query::FilterEntry {
     fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
-        let operators = ["eq", "ne", "lt", "lte", "gt", "gte", "contains", "in"];
+        use crate::query::FilterOp;
+        let ops = [
+            FilterOp::Eq,
+            FilterOp::Neq,
+            FilterOp::Lt,
+            FilterOp::Lte,
+            FilterOp::Gt,
+            FilterOp::Gte,
+            FilterOp::Contains,
+            FilterOp::In,
+        ];
         Self::new(
             gen_str(rng),
-            operators[rng.random_range(0..operators.len())],
+            ops[rng.random_range(0..ops.len())],
             gen_str(rng),
         )
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,7 +217,7 @@ pub use pagination::{
 pub use pagination::{KeysetPaginatedResponse, KeysetPaginationParams};
 pub use query::SortDirection;
 #[cfg(any(feature = "std", feature = "alloc"))]
-pub use query::{FilterEntry, FilterParams, SearchParams, SortParams};
+pub use query::{FilterEntry, FilterOp, FilterParams, SearchParams, SortParams};
 #[cfg(any(feature = "std", feature = "alloc"))]
 pub use range::{ByteRange, ContentRange, ParseRangeError, RangeHeader};
 #[cfg(any(feature = "std", feature = "alloc"))]

--- a/src/query.rs
+++ b/src/query.rs
@@ -130,13 +130,58 @@ impl SortParams {
 }
 
 // ---------------------------------------------------------------------------
-// FilterParams
+// FilterOp + FilterParams
 // ---------------------------------------------------------------------------
 
-/// A single filter triple: `field`, `operator`, `value`.
+/// Filter comparison operator. Closed set — wire and Rust agree on the
+/// vocabulary so per-service operator dialects ("eq" vs "equal" vs "==")
+/// can't drift.
+///
+/// Mirrors `bones.v1.FilterOp` in `proto/bones/v1/queries.proto`.
+#[cfg(any(feature = "std", feature = "alloc"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(rename_all = "snake_case")
+)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "proptest", derive(proptest_derive::Arbitrary))]
+pub enum FilterOp {
+    /// `field == value`.
+    Eq,
+    /// `field != value`.
+    Neq,
+    /// `field > value`.
+    Gt,
+    /// `field >= value`.
+    Gte,
+    /// `field < value`.
+    Lt,
+    /// `field <= value`.
+    Lte,
+    /// Membership; `value` carries a server-defined separator (default ',').
+    In,
+    /// Non-membership; `value` carries a separator-joined list.
+    NotIn,
+    /// Substring match on string fields.
+    Contains,
+    /// Prefix match on string fields.
+    StartsWith,
+    /// Suffix match on string fields.
+    EndsWith,
+    /// Field is present; `value` ignored.
+    Exists,
+    /// Field is absent; `value` ignored.
+    NotExists,
+}
+
+/// A single filter triple: `field`, `op`, `value`.
 ///
 /// ```json
-/// {"field": "status", "operator": "eq", "value": "active"}
+/// {"field": "status", "op": "eq", "value": "active"}
 /// ```
 #[cfg(any(feature = "std", feature = "alloc"))]
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -148,9 +193,11 @@ impl SortParams {
 pub struct FilterEntry {
     /// The field name to filter on.
     pub field: String,
-    /// The comparison operator (e.g. `"eq"`, `"neq"`, `"gt"`, `"lt"`, `"contains"`).
-    pub operator: String,
-    /// The value to compare against.
+    /// The comparison operator. Closed enum — services cannot accept
+    /// off-list operators.
+    pub op: FilterOp,
+    /// The value to compare against. For `In` / `NotIn` this is a
+    /// separator-joined list; for `Exists` / `NotExists` it is ignored.
     pub value: String,
 }
 
@@ -161,22 +208,18 @@ impl FilterEntry {
     /// # Examples
     ///
     /// ```
-    /// use api_bones::query::FilterEntry;
+    /// use api_bones::query::{FilterEntry, FilterOp};
     ///
-    /// let entry = FilterEntry::new("status", "eq", "active");
+    /// let entry = FilterEntry::new("status", FilterOp::Eq, "active");
     /// assert_eq!(entry.field, "status");
-    /// assert_eq!(entry.operator, "eq");
+    /// assert_eq!(entry.op, FilterOp::Eq);
     /// assert_eq!(entry.value, "active");
     /// ```
     #[must_use]
-    pub fn new(
-        field: impl Into<String>,
-        operator: impl Into<String>,
-        value: impl Into<String>,
-    ) -> Self {
+    pub fn new(field: impl Into<String>, op: FilterOp, value: impl Into<String>) -> Self {
         Self {
             field: field.into(),
-            operator: operator.into(),
+            op,
             value: value.into(),
         }
     }
@@ -188,7 +231,7 @@ impl FilterEntry {
 /// AND-combined by convention; consumers may choose different semantics.
 ///
 /// ```json
-/// {"filters": [{"field": "status", "operator": "eq", "value": "active"}]}
+/// {"filters": [{"field": "status", "op": "eq", "value": "active"}]}
 /// ```
 #[cfg(any(feature = "std", feature = "alloc"))]
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -210,9 +253,9 @@ impl FilterParams {
     /// # Examples
     ///
     /// ```
-    /// use api_bones::query::{FilterParams, FilterEntry};
+    /// use api_bones::query::{FilterParams, FilterEntry, FilterOp};
     ///
-    /// let f = FilterParams::new([FilterEntry::new("status", "eq", "active")]);
+    /// let f = FilterParams::new([FilterEntry::new("status", FilterOp::Eq, "active")]);
     /// assert!(!f.is_empty());
     /// assert_eq!(f.filters.len(), 1);
     /// ```
@@ -497,21 +540,44 @@ mod tests {
 
     #[test]
     fn filter_params_new() {
-        let f = FilterParams::new([FilterEntry::new("status", "eq", "active")]);
+        let f = FilterParams::new([FilterEntry::new("status", FilterOp::Eq, "active")]);
         assert!(!f.is_empty());
         assert_eq!(f.filters.len(), 1);
         assert_eq!(f.filters[0].field, "status");
-        assert_eq!(f.filters[0].operator, "eq");
+        assert_eq!(f.filters[0].op, FilterOp::Eq);
         assert_eq!(f.filters[0].value, "active");
     }
 
     #[cfg(feature = "serde")]
     #[test]
     fn filter_params_serde_round_trip() {
-        let f = FilterParams::new([FilterEntry::new("age", "gt", "18")]);
+        let f = FilterParams::new([FilterEntry::new("age", FilterOp::Gt, "18")]);
         let json = serde_json::to_value(&f).unwrap();
         let back: FilterParams = serde_json::from_value(json).unwrap();
         assert_eq!(back, f);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn filter_op_serde_snake_case() {
+        assert_eq!(
+            serde_json::to_value(FilterOp::Eq).unwrap(),
+            serde_json::json!("eq")
+        );
+        assert_eq!(
+            serde_json::to_value(FilterOp::Neq).unwrap(),
+            serde_json::json!("neq")
+        );
+        assert_eq!(
+            serde_json::to_value(FilterOp::StartsWith).unwrap(),
+            serde_json::json!("starts_with")
+        );
+        assert_eq!(
+            serde_json::to_value(FilterOp::NotExists).unwrap(),
+            serde_json::json!("not_exists")
+        );
+        let back: FilterOp = serde_json::from_value(serde_json::json!("gte")).unwrap();
+        assert_eq!(back, FilterOp::Gte);
     }
 
     #[cfg(feature = "serde")]

--- a/tests/fake_smoke.rs
+++ b/tests/fake_smoke.rs
@@ -202,7 +202,9 @@ fn fake_sort_params() {
 fn fake_filter_entry() {
     smoke::<api_bones::FilterEntry, _>(200, |v| {
         assert!(!v.field.is_empty());
-        assert!(!v.operator.is_empty());
+        // `op` is an enum with `Unspecified` not in the variant set; any value
+        // generated is valid by construction. Field-presence is the only
+        // shape check we need.
     });
 }
 


### PR DESCRIPTION
## Summary

Establishes the proto-side companion to the api-bones Rust crate: canonical `.proto` shapes that services compose into their wire contracts, distributed via a new zero-dep `api-bones-protos` crate.

## What this ships

### Canonical proto shapes (`proto/bones/v1/`)

| File | Shapes |
|---|---|
| `pagination.proto` | `PageRequest`, `PageResponse` (cursor, AIP-158); `OffsetPageRequest`, `OffsetPageResponse` (offset/limit). `PageResponse.revision` doubles as the list-level ETag. |
| `queries.proto` | `SortDirection`, `SortField`, `SortParams`; `FilterOp` (closed enum, 13 variants); `FilterEntry`, `FilterParams`; `SearchParams`. |
| `errors.proto` | `ValidationFailure { field, message, rule }` — composes into Connect's error envelope `details[]`. |
| `ratelimit.proto` | `RateLimitInfo { limit, remaining, reset, retry_after }` — typed response metadata. |

The proto-side `FilterOp` is a **closed enum** — services MUST NOT accept off-list operators on the wire, locking out per-service dialects ("eq" vs "equal" vs "==").

`proto/README.md` catalogs every shape with its Rust counterpart and a skip-list documenting which api-bones types deliberately have NO proto equivalent (Connect envelope, HATEOAS links, HTTP-header types, branded-ID wrappers, `grpc.health.v1`-standardized health types, etc.).

`proto/buf.yaml` (v2) declares the module with `STANDARD` lint (minus `PACKAGE_VERSION_SUFFIX`) and `FILE`-level breaking-change rules.

### CI gates

- `make proto-lint` — runs `buf lint proto`.
- `make proto-breaking` — runs `buf breaking proto --against origin/main` with a baseline-empty guard (skips on the first PR introducing the proto/ dir).
- `.github/workflows/proto.yml` — wires both into PR/push CI.

### Rust-side breaking change (5.0.0 → 6.0.0)

- **`FilterEntry.operator: String` → `FilterEntry.op: FilterOp`**. Locks the Rust counterpart to the same closed enum as `bones.v1.FilterOp`. JSON field name changes `"operator"` → `"op"`; serialized documents need migration.
- New `FilterOp` enum re-exported from the crate root; serde rename `"snake_case"` (`eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `in`, `not_in`, `contains`, `starts_with`, `ends_with`, `exists`, `not_exists`).
- Updated `src/query.rs`, `src/fake_impls.rs`, `src/lib.rs`, `examples/query_params.rs`, `tests/fake_smoke.rs`.
- Workspace path-dep versions in `api-bones-reqwest`, `api-bones-test`, `api-bones-tower` bumped `"5.0"` → `"6.0"`.

### New workspace member: `api-bones-protos` (0.1.0)

Tiny crate (~80 lines) that ships the four `bones/v1/*.proto` files via `include_bytes!` and exposes one accessor:

```rust
pub fn files() -> impl Iterator<Item = (&'static str, &'static [u8])>;
```

Zero runtime dependencies. Pairs with [`proto-build-kit`](https://github.com/brefwiz/proto-build-kit)'s `Stager` (or any equivalent staging library) at consumer build time:

```rust
let staged = proto_build_kit::Stager::new()
    .with(api_bones_protos::files())
    .stage()?;

connectrpc_build::Config::new()
    .files(&["proto/my/v1/svc.proto"])
    .includes(&["proto/", staged.path()])
    .include_file("_connectrpc.rs")
    .compile()?;
```

Five unit tests assert: four files yielded, paths unique, every embedded bytes non-empty, pagination.proto declares the four expected messages, queries.proto declares `FilterOp`.

The crate's semver tracks the SHAPE of the proto files it ships — adding a new `bones.v1.*` message is a minor bump; a breaking proto change (rename, package bump) is a major. Decoupled from `api-bones`'s 6.x.

## Test plan

- [x] `make ci-format` clean
- [x] `make ci-lint` clean
- [x] `make ci-test` — workspace passes with the new tests
- [x] `make proto-lint` clean
- [x] `make proto-breaking` clean (baseline-empty guard kicks in for this first PR)

## CHANGELOG

`CHANGELOG.md` 6.0.0 entry includes the FilterOp migration snippet.
