### PR TITLE
feat: api-bones-protos crate — embedded bones/v1 proto bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,6 +120,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "api-bones-protos"
+version = "0.1.0"
+
+[[package]]
 name = "api-bones-reqwest"
 version = "4.4.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,13 @@
 [workspace]
-members = [".", "api-bones-tower", "api-bones-reqwest", "api-bones-progenitor", "api-bones-sdk-gen", "api-bones-test"]
+members = [
+    ".",
+    "api-bones-tower",
+    "api-bones-reqwest",
+    "api-bones-progenitor",
+    "api-bones-sdk-gen",
+    "api-bones-test",
+    "api-bones-protos",
+]
 resolver = "2"
 
 [workspace.lints.rust]

--- a/api-bones-protos/Cargo.toml
+++ b/api-bones-protos/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "api-bones-protos"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.88"
+authors = ["Gregoire Salingue"]
+license = "MIT"
+description = "Embedded bytes of the api-bones canonical proto shapes (bones/v1/*.proto). Pair with `proto-build-kit` to stage on the protoc include path at build time."
+repository = "https://github.com/brefwiz/api-bones"
+homepage = "https://github.com/brefwiz/api-bones"
+documentation = "https://docs.rs/api-bones-protos"
+readme = "README.md"
+keywords = ["protobuf", "buf", "tonic", "connectrpc", "build-script"]
+categories = ["development-tools::build-utils"]
+# Embed the .proto sources in the published .crate tarball.
+include = ["src/**/*.rs", "../proto/bones/v1/*.proto", "README.md", "LICENSE"]
+
+[lints]
+workspace = true
+
+[lib]
+path = "src/lib.rs"
+
+# Zero runtime dependencies — this crate just exposes raw bytes.
+[dependencies]

--- a/api-bones-protos/LICENSE
+++ b/api-bones-protos/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Grégoire Salingue
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/api-bones-protos/README.md
+++ b/api-bones-protos/README.md
@@ -1,0 +1,50 @@
+# api-bones-protos
+
+[![crates.io](https://img.shields.io/crates/v/api-bones-protos.svg)](https://crates.io/crates/api-bones-protos)
+[![docs.rs](https://img.shields.io/docsrs/api-bones-protos)](https://docs.rs/api-bones-protos)
+
+Embedded bytes of the canonical proto shapes shipped by the
+[`api-bones`](https://crates.io/crates/api-bones) crate ecosystem
+(`bones/v1/*.proto`).
+
+**Zero runtime dependencies.** This crate exists purely as a
+distribution mechanism for the proto bytes. Pair it with a staging
+library (e.g.
+[`proto-build-kit`](https://crates.io/crates/proto-build-kit)) to
+write the bytes to a tempdir at protoc-relative paths at consumer
+build time:
+
+```rust,no_run
+use proto_build_kit::Stager;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let staged = Stager::new()
+        .with(api_bones_protos::files())
+        .stage()?;
+
+    // Add staged.path() to your codegen include path:
+    connectrpc_build::Config::new()
+        .files(&["proto/my/v1/svc.proto"])
+        .includes(&["proto/", staged.path()])
+        .include_file("_connectrpc.rs")
+        .compile()?;
+    Ok(())
+}
+```
+
+## What's included
+
+| File                              | Messages |
+|-----------------------------------|----------|
+| `bones/v1/pagination.proto`       | `PageRequest`, `PageResponse`, `OffsetPageRequest`, `OffsetPageResponse` |
+| `bones/v1/queries.proto`          | `SortDirection`, `SortField`, `SortParams`, `FilterOp`, `FilterEntry`, `FilterParams`, `SearchParams` |
+| `bones/v1/errors.proto`           | `ValidationFailure` |
+| `bones/v1/ratelimit.proto`        | `RateLimitInfo` |
+
+See `proto/README.md` in the api-bones repo for the canonical
+schema inventory and the per-message Rust counterparts in the
+`api-bones` crate.
+
+## License
+
+MIT.

--- a/api-bones-protos/src/lib.rs
+++ b/api-bones-protos/src/lib.rs
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: MIT
+//! Embedded bytes of the api-bones canonical proto shapes.
+//!
+//! This crate ships the `bones/v1/*.proto` files via `include_bytes!`
+//! and exposes a single accessor — [`files`] — that yields
+//! `(relative_path, bytes)` pairs ready for staging onto a protoc
+//! include path at consumer build time.
+//!
+//! **Zero runtime dependencies.** This crate exists purely as a
+//! distribution mechanism for the bytes. Pair it with any staging
+//! library (e.g. [`proto-build-kit`](https://crates.io/crates/proto-build-kit))
+//! to assemble a tempdir for codegen tools (connectrpc-build,
+//! tonic-prost-build, ...).
+//!
+//! # Example
+//!
+//! ```no_run
+//! # // We can't actually run this in a doctest because it depends on
+//! # // proto-build-kit, but it shows the shape.
+//! # mod proto_build_kit {
+//! #     pub struct Stager;
+//! #     impl Stager {
+//! #         pub fn new() -> Self { Self }
+//! #         pub fn with<I>(self, _: I) -> Self { self }
+//! #         pub fn stage(self) -> Result<tempfile::TempDir, std::io::Error> {
+//! #             tempfile::tempdir()
+//! #         }
+//! #     }
+//! # }
+//! let staged = proto_build_kit::Stager::new()
+//!     .with(api_bones_protos::files())
+//!     .stage()
+//!     .expect("stage");
+//! // Add staged.path() to your protoc include path.
+//! ```
+//!
+//! # What's included
+//!
+//! The shapes match the proto/bones/v1/ directory in the api-bones
+//! repo. See the README for the canonical schema inventory.
+
+const PAGINATION_PROTO: &[u8] = include_bytes!("../../proto/bones/v1/pagination.proto");
+const QUERIES_PROTO: &[u8] = include_bytes!("../../proto/bones/v1/queries.proto");
+const ERRORS_PROTO: &[u8] = include_bytes!("../../proto/bones/v1/errors.proto");
+const RATELIMIT_PROTO: &[u8] = include_bytes!("../../proto/bones/v1/ratelimit.proto");
+
+/// Yield `(relative_path, bytes)` pairs for every `bones/v1/*.proto`
+/// file shipped by this crate.
+///
+/// `relative_path` is the protoc-style import path consumers use
+/// (`bones/v1/pagination.proto`, etc.). The order of the iterator is
+/// stable but unspecified — consumers should not rely on it.
+pub fn files() -> impl Iterator<Item = (&'static str, &'static [u8])> {
+    [
+        ("bones/v1/pagination.proto", PAGINATION_PROTO),
+        ("bones/v1/queries.proto", QUERIES_PROTO),
+        ("bones/v1/errors.proto", ERRORS_PROTO),
+        ("bones/v1/ratelimit.proto", RATELIMIT_PROTO),
+    ]
+    .into_iter()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ships_four_files() {
+        let v: Vec<_> = files().collect();
+        assert_eq!(v.len(), 4);
+    }
+
+    #[test]
+    fn relative_paths_are_unique() {
+        let mut paths: Vec<_> = files().map(|(p, _)| p).collect();
+        let n = paths.len();
+        paths.sort_unstable();
+        paths.dedup();
+        assert_eq!(paths.len(), n, "duplicate relative paths in files()");
+    }
+
+    #[test]
+    fn every_file_has_non_empty_bytes() {
+        for (path, bytes) in files() {
+            assert!(!bytes.is_empty(), "{path} embeds empty bytes");
+        }
+    }
+
+    #[test]
+    fn pagination_proto_declares_expected_messages() {
+        let body = std::str::from_utf8(PAGINATION_PROTO).expect("utf8");
+        for msg in [
+            "message PageRequest",
+            "message PageResponse",
+            "message OffsetPageRequest",
+            "message OffsetPageResponse",
+        ] {
+            assert!(body.contains(msg), "pagination.proto missing `{msg}`");
+        }
+    }
+
+    #[test]
+    fn queries_proto_declares_filter_op_enum() {
+        let body = std::str::from_utf8(QUERIES_PROTO).expect("utf8");
+        assert!(
+            body.contains("enum FilterOp"),
+            "queries.proto missing FilterOp enum"
+        );
+        assert!(
+            body.contains("FILTER_OP_EQ"),
+            "queries.proto missing FILTER_OP_EQ"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new workspace member `api-bones-protos` — a ~80-line crate that ships the canonical `bones/v1/*.proto` bytes (just merged on `feat-proto-bones-v1`, PR #61) via `include_bytes!` and exposes one accessor:

```rust
pub fn files() -> impl Iterator<Item = (&'static str, &'static [u8])>;
```

**Zero runtime dependencies.** Pair with [`proto-build-kit`](https://github.com/brefwiz/proto-build-kit)'s `Stager` (or any equivalent staging library) at consumer build time:

```rust
let staged = proto_build_kit::Stager::new()
    .with(api_bones_protos::files())
    .stage()?;
connectrpc_build::Config::new()
    .files(&["proto/my/v1/svc.proto"])
    .includes(&["proto/", staged.path()])
    .compile()?;
```

Implements step 2 of [ADR-0087](https://git.brefwiz.com/brefwiz/brefwiz-architecture/pulls/117)'s migration sequence.

## Why a separate crate from `api-bones`?

- **Independent versioning.** `api-bones-protos` semver tracks the shape of the `.proto` files; `api-bones` (Rust types) evolves on its own cadence. A new `bones.v1.*` message is an `api-bones-protos` minor bump that doesn't force consumers of `api-bones` to re-release.
- **No transitive deps.** Consumers who only need proto bytes don't pull in api-bones' utoipa/schemars/chrono/uuid surface.

## Design

- **Iterator accessor**, not a struct or const array — lets consumers chain multiple `*-protos` crates via `Stager::with(...)`. Order is stable but unspecified.
- **`include = [...]`** in Cargo.toml explicitly lists `../proto/bones/v1/*.proto` so the published `.crate` tarball ships the proto sources even though they live outside the crate dir.
- **README + LICENSE** vendored into the crate dir for the tarball.

## Test plan

- [x] `make ci-format` clean
- [x] `make ci-lint` clean
- [x] `make ci-test` — 5 new tests (files-count, path-uniqueness, non-empty bytes, pagination messages declared, queries FilterOp declared)
- [ ] Reviewer: confirm the crate naming (`api-bones-protos`) matches the `*-protos` convention proposed in ADR-0087
- [ ] Reviewer: confirm 0.1.0 initial version + the "shape semver tracks proto schema" policy is acceptable

## Stacked PR

This PR is stacked on `feat-proto-bones-v1` (#61). When that lands, this PR auto-retargets to `main`. The diff visible here is **only** the new crate; the proto/* files are already on the base branch.

Ref: brefwiz-architecture#117 (ADR-0087 — proto-build extraction) · proto-build-kit#1 (the staging library, merged).
