### PR TITLE
ci: add api-bones-protos to release.yml crates list

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     with:
       # Publish in dependency order: api-bones must land on crates.io before
       # the satellite crates can resolve it.
-      crates: "api-bones api-bones-tower api-bones-reqwest api-bones-progenitor api-bones-sdk-gen api-bones-test"
+      crates: "api-bones api-bones-tower api-bones-reqwest api-bones-progenitor api-bones-sdk-gen api-bones-test api-bones-protos"
     secrets:
       cargo-registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
     permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ api-bones-reqwest/Cargo.lock
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+api-bones-axios/*.tgz


### PR DESCRIPTION
## Summary

`api-bones 6.0.0` published successfully on `v6.0.0`, but the new `api-bones-protos` workspace member (added in #61) is missing from `release.yml`'s `crates:` input — so it didn't ship to crates.io. Confirmed:

```
$ cargo search api-bones-protos
(no results)
```

Adds it to the publish list. Also adds `api-bones-axios/*.tgz` to `.gitignore` — leftover build artifact has been getting accidentally staged across PRs.

## Backfill

The shared [`release-rust.yml`](https://github.com/brefwiz/shared-ci-workflows/blob/main/.github/workflows/release-rust.yml) is confirmed idempotent — it checks each crate against `crates.io/api/v1/crates/<name>/<version>` and `continue`s when the version is already indexed:

```bash
for CRATE in ${{ inputs.crates }}; do
    CRATE_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r ...)
    if curl -sf "https://crates.io/api/v1/crates/${CRATE}/${CRATE_VERSION}" ...; then
      echo "==> Skipping ${CRATE} ${CRATE_VERSION} (already on crates.io)"
      continue
    fi
    cargo publish -p "${CRATE}"
done
```

After this PR lands: manually re-run the **Release** workflow against the existing `v6.0.0` tag from the GitHub Actions UI. It will skip api-bones (6.0.0 indexed) and every satellite (4.4.0 indexed), and publish only `api-bones-protos 0.1.0`.

## Test plan

- [x] Confirmed shared release-rust.yml skips already-published crates (inspected source).
- [ ] On merge + manual re-run against v6.0.0: verify `cargo search api-bones-protos` returns 0.1.0.
