### PR TITLE
feat(connect): proto adapter primitives for Connect RPC — v6.1.0 (ADR-0096)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.1.0] — 2026-05-19
+
+### Added
+
+- **`connect` feature** — proto adapter primitives for Connect RPC services (ADR-0096).
+  Enable with `features = ["connect"]`. Provides:
+  - `chrono_to_timestamp` / `chrono_opt_to_timestamp` — `DateTime<Utc>` → `google.protobuf.Timestamp`
+  - `parse_uuid(s, field)` — UUID parsing with field attribution in `ConnectError`
+  - `build_page` / `build_offset_page` / `OffsetPage` — offset pagination newtype with private constructor (compile-time enforcement that `build_page` is the only entry point)
+  - `ConnectOptionExt` — sealed extension trait on `Result<Option<T>, E>` for ergonomic `or_not_found` shaping
+  - Zero cost for non-connect consumers — all deps are optional behind the feature flag.
+
 ## [6.0.0] — 2026-05-16
 
 ### Breaking

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -84,12 +90,14 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-bones"
-version = "6.0.0"
+version = "6.1.0"
 dependencies = [
  "arbitrary",
  "axum",
  "base64 0.22.1",
+ "buffa-types",
  "chrono",
+ "connectrpc",
  "fake",
  "hmac",
  "http",
@@ -214,6 +222,18 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "xattr",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -509,6 +529,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "buffa"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a22fed63b429c4928fd5ed18dcacd3a98d0df1f06cd7cf651b2bbf3dbf0500"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "hashbrown 0.15.5",
+ "once_cell",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "buffa-types"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d406a92c781273688fa21eb2641b54b2cf4e6b52e4a1339fd12279b8220313c"
+dependencies = [
+ "buffa",
+ "bytes",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -536,6 +584,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -628,7 +678,54 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
+
+[[package]]
+name = "connectrpc"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cb80f9eb09b593a96880eb1c2588ac6319b129519de8c672f9b8b4ffdeaece"
+dependencies = [
+ "async-compression",
+ "base64 0.22.1",
+ "buffa",
+ "bytes",
+ "flate2",
+ "futures",
+ "http",
+ "http-body",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tracing",
+ "wasm-bindgen-futures",
+ "zstd",
 ]
 
 [[package]]
@@ -695,6 +792,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1008,7 +1114,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1100,6 +1206,17 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+ "zlib-rs",
+]
 
 [[package]]
 name = "fnv"
@@ -1310,6 +1427,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "foldhash 0.1.5",
+ "serde",
 ]
 
 [[package]]
@@ -1772,6 +1890,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1857,6 +1985,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -2755,7 +2893,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3156,6 +3294,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3296,7 +3440,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4484,7 +4628,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ pedantic = { level = "deny", priority = -1 }
 
 [package]
 name = "api-bones"
-version = "6.0.0"
+version = "6.1.0"
 edition = "2024"
 authors = ["Gregoire Salingue"]
 license = "MIT"
@@ -47,6 +47,11 @@ serde = ["dep:serde", "dep:serde_json", "uuid?/serde", "chrono?/serde", "std"]
 base64 = ["alloc", "dep:base64"]
 uuid = ["dep:uuid"]
 chrono = ["dep:chrono", "utoipa?/chrono"]
+## Proto adapter primitives for Connect RPC services (ADR-0096).
+## Provides chrono_to_timestamp, parse_uuid, build_page (OffsetPage), and
+## ConnectOptionExt. Activates the uuid and chrono features as side-effects.
+## Zero impact on consumers who do not declare this feature.
+connect = ["dep:connectrpc", "dep:buffa-types", "uuid", "chrono"]
 http = ["dep:http", "alloc"]
 axum = ["dep:axum", "http", "serde", "std"]
 utoipa = ["dep:utoipa", "std"]
@@ -80,6 +85,10 @@ schemars = { version = "1", optional = true }
 base64 = { version = "0.22", default-features = false, features = ["alloc"], optional = true }
 hmac = { version = "0.13", optional = true }
 sha2 = { version = "0.11", optional = true }
+# connect feature — versions must match what buffa-types / generated proto code use.
+# Mismatch causes type-laundering pain at adapter boundaries (ADR-0096).
+connectrpc  = { version = "0.4", optional = true }
+buffa-types = { version = "0.5", features = ["json"], optional = true }
 
 [lints.rust]
 # Allow cfg(coverage) set by cargo-llvm-cov

--- a/examples/connect_adapter.rs
+++ b/examples/connect_adapter.rs
@@ -1,0 +1,65 @@
+//! Demonstrates the `connect` feature: proto adapter primitives for Connect RPC services.
+//!
+//! Run with:
+//!   cargo run --example connect_adapter --features connect
+
+#[cfg(feature = "connect")]
+fn main() {
+    use api_bones::connect::{
+        ConnectOptionExt as _, build_page, chrono_opt_to_timestamp, chrono_to_timestamp,
+        parse_uuid,
+    };
+
+    // ── Timestamp conversion ───────────────────────────────────────────────
+    let now = chrono::Utc::now();
+    let ts = chrono_to_timestamp(now);
+    println!("Timestamp: seconds={}, nanos={}", ts.seconds, ts.nanos);
+
+    let opt_ts = chrono_opt_to_timestamp(Some(now));
+    assert!(opt_ts.is_some());
+    let none_ts = chrono_opt_to_timestamp(None);
+    assert!(none_ts.is_none());
+
+    // ── UUID parsing ───────────────────────────────────────────────────────
+    let id = parse_uuid("550e8400-e29b-41d4-a716-446655440000", "org_id")
+        .expect("valid UUID should parse");
+    println!("Parsed UUID: {id}");
+
+    let err = parse_uuid("not-a-uuid", "org_id").unwrap_err();
+    println!("Parse error (expected): {err:?}");
+
+    // ── Offset pagination ──────────────────────────────────────────────────
+    // First page of 20, 100 total items.
+    let page = build_page(0, 0, 20, 100);
+    println!(
+        "Page: limit={}, offset={}, total={}, has_more={}",
+        page.limit(),
+        page.offset(),
+        page.total_count(),
+        page.has_more(),
+    );
+    assert_eq!(page.limit(), 20);
+    assert!(page.has_more());
+
+    // Last page.
+    let last = build_page(20, 80, 20, 100);
+    assert!(!last.has_more());
+
+    // Destructure into proto response fields.
+    let (total_count, has_more, limit, offset) = page.into_parts();
+    println!("parts: total={total_count}, has_more={has_more}, limit={limit}, offset={offset}");
+
+    // ── ConnectOptionExt ───────────────────────────────────────────────────
+    let found: Result<Option<&str>, connectrpc::ConnectError> = Ok(Some("hello"));
+    assert_eq!(found.or_not_found("missing").unwrap(), "hello");
+
+    let missing: Result<Option<&str>, connectrpc::ConnectError> = Ok(None);
+    assert!(missing.or_not_found("record not found").is_err());
+
+    println!("All connect adapter primitives OK");
+}
+
+#[cfg(not(feature = "connect"))]
+fn main() {
+    eprintln!("Run with --features connect");
+}

--- a/examples/connect_adapter.rs
+++ b/examples/connect_adapter.rs
@@ -1,13 +1,12 @@
 //! Demonstrates the `connect` feature: proto adapter primitives for Connect RPC services.
 //!
 //! Run with:
-//!   cargo run --example connect_adapter --features connect
+//!   cargo run --example `connect_adapter` --features connect
 
 #[cfg(feature = "connect")]
 fn main() {
     use api_bones::connect::{
-        ConnectOptionExt as _, build_page, chrono_opt_to_timestamp, chrono_to_timestamp,
-        parse_uuid,
+        ConnectOptionExt as _, build_page, chrono_opt_to_timestamp, chrono_to_timestamp, parse_uuid,
     };
 
     // ── Timestamp conversion ───────────────────────────────────────────────

--- a/src/connect/ext.rs
+++ b/src/connect/ext.rs
@@ -64,7 +64,11 @@ mod tests {
         let res: Result<Option<u32>, ConnectError> = Ok(None);
         let err = res.or_not_found("thing not found").unwrap_err();
         let msg = format!("{err:?}");
-        assert!(msg.contains("not_found") || msg.contains("NotFound") || msg.contains("thing not found"));
+        assert!(
+            msg.contains("not_found")
+                || msg.contains("NotFound")
+                || msg.contains("thing not found")
+        );
     }
 
     #[test]

--- a/src/connect/ext.rs
+++ b/src/connect/ext.rs
@@ -1,0 +1,75 @@
+use connectrpc::ConnectError;
+
+mod private {
+    pub trait Sealed {}
+    impl<T, E> Sealed for Result<Option<T>, E> {}
+}
+
+/// Extension trait on `Result<Option<T>, E>` for ergonomic not-found shaping.
+///
+/// Sealed — only `api-bones` provides an implementation. Reimplementing in
+/// service code produces a different trait that will not satisfy imports using
+/// this path, making the canonical combinator mandatory at call sites that
+/// import it (ADR-0096 §Enforcement Level 1).
+///
+/// # Example
+///
+/// ```rust
+/// use api_bones::connect::ConnectOptionExt as _;
+/// use connectrpc::ConnectError;
+///
+/// async fn get_record(id: u64) -> Result<String, ConnectError> {
+///     let row: Option<String> = None; // e.g. from a DB lookup
+///     Ok(Ok::<_, ConnectError>(row).or_not_found("record not found")?)
+/// }
+/// ```
+pub trait ConnectOptionExt<T>: private::Sealed {
+    /// Return `ConnectError::not_found(msg)` if the inner value is `None`,
+    /// or propagate the `Err` variant mapped through `Into<ConnectError>`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(ConnectError::not_found(msg))` when `self` is `Ok(None)`.
+    /// Returns `Err(e.into())` when `self` is `Err(e)`.
+    fn or_not_found(self, msg: &str) -> Result<T, ConnectError>
+    where
+        Self: Sized;
+}
+
+impl<T, E> ConnectOptionExt<T> for Result<Option<T>, E>
+where
+    E: Into<ConnectError>,
+{
+    fn or_not_found(self, msg: &str) -> Result<T, ConnectError> {
+        match self {
+            Ok(Some(v)) => Ok(v),
+            Ok(None) => Err(ConnectError::not_found(msg.to_owned())),
+            Err(e) => Err(e.into()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn some_returns_value() {
+        let res: Result<Option<u32>, ConnectError> = Ok(Some(42));
+        assert_eq!(res.or_not_found("gone").unwrap(), 42);
+    }
+
+    #[test]
+    fn none_returns_not_found() {
+        let res: Result<Option<u32>, ConnectError> = Ok(None);
+        let err = res.or_not_found("thing not found").unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(msg.contains("not_found") || msg.contains("NotFound") || msg.contains("thing not found"));
+    }
+
+    #[test]
+    fn err_propagates() {
+        let res: Result<Option<u32>, ConnectError> = Err(ConnectError::internal("boom"));
+        assert!(res.or_not_found("whatever").is_err());
+    }
+}

--- a/src/connect/mod.rs
+++ b/src/connect/mod.rs
@@ -1,0 +1,55 @@
+//! Proto adapter primitives for Connect RPC services (ADR-0096).
+//!
+//! Enable with `features = ["connect"]`:
+//!
+//! ```toml
+//! api-bones = { version = "6", features = ["connect"] }
+//! ```
+//!
+//! # Usage
+//!
+//! ```rust,ignore
+//! use api_bones::connect::{
+//!     chrono_to_timestamp, chrono_opt_to_timestamp,
+//!     parse_uuid,
+//!     build_page, build_offset_page, OffsetPage,
+//!     ConnectOptionExt as _,
+//! };
+//!
+//! // Timestamp conversion
+//! let ts = chrono_to_timestamp(record.created_at);
+//!
+//! // UUID parsing with field attribution in the error message
+//! let org_id = parse_uuid(request.org_id, "org_id")?;
+//!
+//! // Pagination — OffsetPage has a private constructor; build_page is the only entry point
+//! let page = build_page(req.page.limit, req.page.offset, items.len(), total);
+//! let (total_count, has_more, limit, offset) = page.into_parts();
+//!
+//! // Option → not_found
+//! let record = store.get(id).await.map_err(core_to_connect)?.or_not_found("not found")?;
+//! ```
+//!
+//! # Enforcement (ADR-0096)
+//!
+//! Two primitives carry compile-time enforcement:
+//!
+//! - [`OffsetPage`] has a private constructor — only [`build_page`] /
+//!   [`build_offset_page`] can produce one. Call sites expecting `OffsetPage`
+//!   cannot be satisfied by hand-rolled construction.
+//!
+//! - [`ConnectOptionExt`] is sealed — reimplementing the trait in service code
+//!   produces a different trait that will not satisfy imports of this path.
+//!
+//! A CI grep gate (`connect-bones-check`) additionally bans raw
+//! `Uuid::parse_str(` and `Timestamp::from_unix(` calls in adapter modules.
+
+mod ext;
+mod page;
+mod timestamp;
+mod uuid;
+
+pub use ext::ConnectOptionExt;
+pub use page::{DEFAULT_LIMIT, MAX_LIMIT, OffsetPage, build_offset_page, build_page};
+pub use timestamp::{chrono_opt_to_timestamp, chrono_to_timestamp};
+pub use uuid::parse_uuid;

--- a/src/connect/page.rs
+++ b/src/connect/page.rs
@@ -96,7 +96,12 @@ pub fn build_offset_page(
         limit_in.min(max_limit)
     };
     let has_more = offset + (item_count as u64) < total;
-    OffsetPage { total_count: total, has_more, limit, offset }
+    OffsetPage {
+        total_count: total,
+        has_more,
+        limit,
+        offset,
+    }
 }
 
 /// [`build_offset_page`] with brefwiz standard defaults (default=20, max=200).
@@ -113,7 +118,14 @@ pub fn build_offset_page(
 /// ```
 #[must_use]
 pub fn build_page(limit_in: u64, offset: u64, item_count: usize, total: u64) -> OffsetPage {
-    build_offset_page(limit_in, offset, item_count, total, DEFAULT_LIMIT, MAX_LIMIT)
+    build_offset_page(
+        limit_in,
+        offset,
+        item_count,
+        total,
+        DEFAULT_LIMIT,
+        MAX_LIMIT,
+    )
 }
 
 #[cfg(test)]

--- a/src/connect/page.rs
+++ b/src/connect/page.rs
@@ -1,0 +1,175 @@
+//! Offset pagination builder for Connect proto adapters (ADR-0096).
+
+/// Brefwiz standard default page size.
+pub const DEFAULT_LIMIT: u64 = 20;
+/// Brefwiz standard maximum page size.
+pub const MAX_LIMIT: u64 = 200;
+
+/// Normalized offset-page result.
+///
+/// Constructed only via [`build_page`] or [`build_offset_page`] — the inner
+/// fields are private to prevent hand-rolled construction. Call
+/// [`OffsetPage::into_parts`] to destructure into the four values needed to
+/// populate a proto response message.
+///
+/// # Why a newtype?
+///
+/// The private constructor is the enforcement mechanism (ADR-0096 §Enforcement
+/// Level 1): call sites that expect `OffsetPage` cannot be satisfied with an
+/// inline-built response struct, making the canonical builder mandatory at
+/// compile time.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OffsetPage {
+    pub(super) total_count: u64,
+    pub(super) has_more: bool,
+    pub(super) limit: u64,
+    pub(super) offset: u64,
+}
+
+impl OffsetPage {
+    /// Destructure into `(total_count, has_more, limit, offset)`.
+    ///
+    /// Use these values to populate the `page` field of a proto response:
+    ///
+    /// ```rust,ignore
+    /// let page = build_page(req.page.limit, req.page.offset, items.len(), total);
+    /// let (total_count, has_more, limit, offset) = page.into_parts();
+    /// response.page = SomeOffsetPageResponse { total_count, has_more, limit, offset, .. };
+    /// ```
+    #[must_use]
+    pub fn into_parts(self) -> (u64, bool, u64, u64) {
+        (self.total_count, self.has_more, self.limit, self.offset)
+    }
+
+    /// Total number of items across all pages.
+    #[must_use]
+    pub fn total_count(&self) -> u64 {
+        self.total_count
+    }
+
+    /// Whether more items exist beyond this page.
+    #[must_use]
+    pub fn has_more(&self) -> bool {
+        self.has_more
+    }
+
+    /// The effective limit used for this page (after clamping).
+    #[must_use]
+    pub fn limit(&self) -> u64 {
+        self.limit
+    }
+
+    /// The offset used for this page.
+    #[must_use]
+    pub fn offset(&self) -> u64 {
+        self.offset
+    }
+}
+
+/// Normalize inputs and build an [`OffsetPage`].
+///
+/// - `limit_in == 0` → `default_limit`
+/// - `limit_in > max_limit` → clamped to `max_limit`
+/// - `has_more` is derived from `offset + item_count < total`
+///
+/// # Example
+///
+/// ```rust
+/// use api_bones::connect::{build_offset_page, DEFAULT_LIMIT, MAX_LIMIT};
+///
+/// let page = build_offset_page(0, 0, 5, 100, DEFAULT_LIMIT, MAX_LIMIT);
+/// assert_eq!(page.limit(), DEFAULT_LIMIT);
+/// assert!(page.has_more());
+/// ```
+#[must_use]
+pub fn build_offset_page(
+    limit_in: u64,
+    offset: u64,
+    item_count: usize,
+    total: u64,
+    default_limit: u64,
+    max_limit: u64,
+) -> OffsetPage {
+    let limit = if limit_in == 0 {
+        default_limit
+    } else {
+        limit_in.min(max_limit)
+    };
+    let has_more = offset + (item_count as u64) < total;
+    OffsetPage { total_count: total, has_more, limit, offset }
+}
+
+/// [`build_offset_page`] with brefwiz standard defaults (default=20, max=200).
+///
+/// # Example
+///
+/// ```rust
+/// use api_bones::connect::build_page;
+///
+/// let page = build_page(0, 0, 20, 42);
+/// assert_eq!(page.limit(), 20);
+/// assert_eq!(page.total_count(), 42);
+/// assert!(page.has_more());
+/// ```
+#[must_use]
+pub fn build_page(limit_in: u64, offset: u64, item_count: usize, total: u64) -> OffsetPage {
+    build_offset_page(limit_in, offset, item_count, total, DEFAULT_LIMIT, MAX_LIMIT)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zero_limit_uses_default() {
+        let p = build_page(0, 0, 5, 100);
+        assert_eq!(p.limit(), DEFAULT_LIMIT);
+    }
+
+    #[test]
+    fn oversized_limit_clamped() {
+        let p = build_page(9999, 0, 5, 100);
+        assert_eq!(p.limit(), MAX_LIMIT);
+    }
+
+    #[test]
+    fn explicit_limit_preserved() {
+        let p = build_page(50, 0, 5, 100);
+        assert_eq!(p.limit(), 50);
+    }
+
+    #[test]
+    fn has_more_true_when_items_remain() {
+        let p = build_page(20, 0, 20, 100);
+        assert!(p.has_more());
+    }
+
+    #[test]
+    fn has_more_false_on_last_page() {
+        let p = build_page(20, 80, 20, 100);
+        assert!(!p.has_more());
+    }
+
+    #[test]
+    fn has_more_false_on_exact_fit() {
+        let p = build_page(20, 0, 100, 100);
+        assert!(!p.has_more());
+    }
+
+    #[test]
+    fn empty_result_no_more() {
+        let p = build_page(20, 0, 0, 0);
+        assert!(!p.has_more());
+        assert_eq!(p.total_count(), 0);
+    }
+
+    #[test]
+    fn into_parts_destructures() {
+        let p = build_page(10, 5, 10, 50);
+        let (total, has_more, limit, offset) = p.into_parts();
+        assert_eq!(total, 50);
+        assert!(has_more);
+        assert_eq!(limit, 10);
+        assert_eq!(offset, 5);
+    }
+}

--- a/src/connect/timestamp.rs
+++ b/src/connect/timestamp.rs
@@ -1,0 +1,75 @@
+use buffa_types::google::protobuf::Timestamp;
+use chrono::{DateTime, Utc};
+
+/// Convert a [`chrono::DateTime<Utc>`] to a [`google.protobuf.Timestamp`].
+///
+/// # Safety of the subsec cast
+///
+/// `chrono` guarantees `timestamp_subsec_nanos()` is always `< 1_000_000_000`,
+/// so the `as i32` truncation is lossless and the `as u32` → `i32` reinterpret
+/// cannot overflow.
+///
+/// # Example
+///
+/// ```rust
+/// use api_bones::connect::chrono_to_timestamp;
+///
+/// let ts = chrono_to_timestamp(chrono::Utc::now());
+/// assert!(ts.seconds >= 0);
+/// ```
+#[must_use]
+pub fn chrono_to_timestamp(dt: DateTime<Utc>) -> Timestamp {
+    #[allow(clippy::cast_possible_wrap, clippy::cast_possible_truncation)]
+    Timestamp::from_unix(dt.timestamp(), dt.timestamp_subsec_nanos() as i32)
+}
+
+/// Convert an `Option<DateTime<Utc>>` to an optional proto Timestamp.
+///
+/// Returns `None` when the input is `None`, forwarding to [`chrono_to_timestamp`]
+/// otherwise.
+///
+/// # Example
+///
+/// ```rust
+/// use api_bones::connect::chrono_opt_to_timestamp;
+///
+/// assert!(chrono_opt_to_timestamp(None).is_none());
+/// assert!(chrono_opt_to_timestamp(Some(chrono::Utc::now())).is_some());
+/// ```
+#[must_use]
+pub fn chrono_opt_to_timestamp(dt: Option<DateTime<Utc>>) -> Option<Timestamp> {
+    dt.map(chrono_to_timestamp)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone as _;
+
+    #[test]
+    fn epoch_round_trips() {
+        let dt = Utc.timestamp_opt(0, 0).unwrap();
+        let ts = chrono_to_timestamp(dt);
+        assert_eq!(ts.seconds, 0);
+        assert_eq!(ts.nanos, 0);
+    }
+
+    #[test]
+    fn subsec_nanos_preserved() {
+        let dt = Utc.timestamp_opt(1_700_000_000, 123_456_789).unwrap();
+        let ts = chrono_to_timestamp(dt);
+        assert_eq!(ts.seconds, 1_700_000_000);
+        assert_eq!(ts.nanos, 123_456_789);
+    }
+
+    #[test]
+    fn opt_none_stays_none() {
+        assert!(chrono_opt_to_timestamp(None).is_none());
+    }
+
+    #[test]
+    fn opt_some_converts() {
+        let dt = Utc.timestamp_opt(1_000, 0).unwrap();
+        assert!(chrono_opt_to_timestamp(Some(dt)).is_some());
+    }
+}

--- a/src/connect/uuid.rs
+++ b/src/connect/uuid.rs
@@ -1,0 +1,53 @@
+use connectrpc::ConnectError;
+use uuid::Uuid;
+
+/// Parse a UUID string, returning [`ConnectError::invalid_argument`] on failure.
+///
+/// `field` names the request field being parsed and is included in the error
+/// message to aid API callers in locating the problem (e.g. `"org_id"`).
+///
+/// # Example
+///
+/// ```rust
+/// use api_bones::connect::parse_uuid;
+///
+/// let id = parse_uuid("550e8400-e29b-41d4-a716-446655440000", "org_id").unwrap();
+/// assert_eq!(id.to_string(), "550e8400-e29b-41d4-a716-446655440000");
+///
+/// let err = parse_uuid("not-a-uuid", "org_id").unwrap_err();
+/// // ConnectError message contains the field name
+/// ```
+pub fn parse_uuid(s: &str, field: &str) -> Result<Uuid, ConnectError> {
+    Uuid::parse_str(s)
+        .map_err(|_| ConnectError::invalid_argument(format!("invalid UUID in field `{field}`")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_uuid_parses() {
+        let s = "550e8400-e29b-41d4-a716-446655440000";
+        let id = parse_uuid(s, "id").unwrap();
+        assert_eq!(id.to_string(), s);
+    }
+
+    #[test]
+    fn nil_uuid_parses() {
+        let id = parse_uuid("00000000-0000-0000-0000-000000000000", "id").unwrap();
+        assert!(id.is_nil());
+    }
+
+    #[test]
+    fn invalid_returns_error() {
+        let err = parse_uuid("not-a-uuid", "org_id").unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(msg.contains("org_id"));
+    }
+
+    #[test]
+    fn empty_string_returns_error() {
+        assert!(parse_uuid("", "id").is_err());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,6 +141,9 @@ pub mod calendar;
 // OpenAPI helpers: Example<T> and DeprecatedField (issues #119, #120).
 pub mod openapi;
 
+#[cfg(feature = "connect")]
+pub mod connect;
+
 pub mod has_id;
 pub use has_id::HasId;
 


### PR DESCRIPTION
## Summary

- Adds `features = ["connect"]` to api-bones implementing ADR-0096
- Four shared proto adapter primitives for all brefwiz Connect RPC services:
  - `chrono_to_timestamp` / `chrono_opt_to_timestamp` — `DateTime<Utc>` → `google.protobuf.Timestamp`
  - `parse_uuid(s, field)` — UUID parsing with field-attributed `ConnectError`
  - `build_page` / `OffsetPage` — offset pagination newtype; private constructor enforces `build_page` as sole entry point (compile-time equivalent of ADR-0020's `RfcOk<T>`)
  - `ConnectOptionExt` — sealed extension trait on `Result<Option<T>, E>` for ergonomic `or_not_found`
- Zero cost for non-connect consumers — `connectrpc` and `buffa-types` are optional deps
- Bumps version `6.0.0` → `6.1.0`

## Enforcement (ADR-0096)

- `OffsetPage` private constructor — only `build_page` / `build_offset_page` can produce one
- `ConnectOptionExt` sealed — reimplementing in service code yields a different trait
- CI grep gate (`connect-bones-check`) bans raw `Uuid::parse_str(` and `Timestamp::from_unix(` in adapter modules

## Test plan

- [x] `cargo test --features connect` — 19 connect-specific tests + 1034 total pass
- [x] `cargo clippy --features connect -- -D warnings` — zero warnings
- [x] `examples/connect_adapter.rs` demonstrates all new public APIs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
