### PR TITLE
feat(protos): bones.v1.errors MethodOptions extension (ADR-0103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.2.0] — 2026-05-20
+
+### Added
+
+- **`api-bones-protos` 0.2.0 — `bones.v1.errors` MethodOptions extension** (ADR platform/0103).
+  New proto file `proto/bones/v1/annotations.proto` defining a `repeated string errors` extension on `google.protobuf.MethodOptions` at field number 5102347. Every RPC in a `wire_surface: proto-source` service will declare its possible error variants via `option (bones.v1.errors) = "VARIANT"`. Consumers: SDK generators (typed error variants), `/doc-pipeline` coverage gate (one Gherkin scenario per declared variant), runtime error mappers.
+
 ## [6.1.0] — 2026-05-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **`api-bones-protos` 0.2.0 — `bones.v1.errors` MethodOptions extension** (ADR platform/0103).
-  New proto file `proto/bones/v1/annotations.proto` defining a `repeated string errors` extension on `google.protobuf.MethodOptions` at field number 5102347. Every RPC in a `wire_surface: proto-source` service will declare its possible error variants via `option (bones.v1.errors) = "VARIANT"`. Consumers: SDK generators (typed error variants), `/doc-pipeline` coverage gate (one Gherkin scenario per declared variant), runtime error mappers.
+- **`api-bones-protos` 0.2.0 — `bones.v1.errors` MethodOptions extension.**
+  New proto file `proto/bones/v1/annotations.proto` defining a `repeated string errors` extension on `google.protobuf.MethodOptions` at field number 5102347. Lets each RPC declare its error variants on the wire so SDK generators can emit typed error surfaces:
+
+  ```proto
+  rpc Login(LoginRequest) returns (LoginResponse) {
+    option (bones.v1.errors) = "INVALID_CREDENTIALS";
+    option (bones.v1.errors) = "ACCOUNT_LOCKED";
+  }
+  ```
 
 ## [6.1.0] — 2026-05-19
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-bones"
-version = "6.1.0"
+version = "6.2.0"
 dependencies = [
  "arbitrary",
  "axum",
@@ -129,7 +129,7 @@ dependencies = [
 
 [[package]]
 name = "api-bones-protos"
-version = "0.1.0"
+version = "0.2.0"
 
 [[package]]
 name = "api-bones-reqwest"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ pedantic = { level = "deny", priority = -1 }
 
 [package]
 name = "api-bones"
-version = "6.1.0"
+version = "6.2.0"
 edition = "2024"
 authors = ["Gregoire Salingue"]
 license = "MIT"

--- a/api-bones-protos/Cargo.toml
+++ b/api-bones-protos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api-bones-protos"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["Gregoire Salingue"]

--- a/api-bones-protos/proto/bones/v1/annotations.proto
+++ b/api-bones-protos/proto/bones/v1/annotations.proto
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: LicenseRef-Proprietary
+//
+// Method-level annotations for service authors.
+//
+// `bones.v1.errors` — the declared error contract for an RPC, per
+// ADR platform/0103. Every RPC in a `wire_surface: proto-source`
+// service must declare the error variants it may return. Variant
+// names are ALL_CAPS_SNAKE strings that reference the service's
+// companion error enum (the enum itself is service-owned; this
+// option just enumerates which variants apply per RPC).
+//
+// Usage:
+//
+//   service AuthService {
+//     rpc Login(LoginRequest) returns (LoginResponse) {
+//       option (bones.v1.errors) = "INVALID_CREDENTIALS";
+//       option (bones.v1.errors) = "ACCOUNT_LOCKED";
+//       option (bones.v1.errors) = "MFA_REQUIRED";
+//     }
+//   }
+//
+// Consumers of the annotation:
+//
+//   - SDK generators (api-bones-sdk-gen) — emit typed error variants
+//     in the SDK per declared variant; undeclared runtime errors map
+//     to a catch-all `Unknown(google.rpc.Status)` variant.
+//   - `/doc-pipeline` coverage gate (ADR platform/0102) — requires
+//     one `@endpoint:<rpc> @state:<variant>` Gherkin scenario per
+//     declared variant + one for the happy path.
+//   - Runtime error mappers (server-side, optional) — assert at
+//     handler return that any error returned matches a declared
+//     variant; refuse to ship undeclared errors over the wire.
+//
+// Enforcement:
+//
+//   1. Compile-time (preferred): a buf lint rule (or custom protoc
+//      plugin) emits a build error when an RPC in a proto-source
+//      repo has zero `option (bones.v1.errors)` annotations.
+//   2. `make proto-errors-check` (guaranteed floor): parses proto
+//      descriptors and fails on RPCs missing the annotation. Lives
+//      in the api-bones make-include consumed by every service.
+//
+// Allowlist for legitimately error-free RPCs (e.g. Healthz) lives
+// in the service's `buf.yaml` lint config, not here.
+
+syntax = "proto3";
+
+package bones.v1;
+
+import "google/protobuf/descriptor.proto";
+
+extend google.protobuf.MethodOptions {
+  // Declared error variants for this RPC. Variant names are
+  // ALL_CAPS_SNAKE and must match a value in the service's
+  // companion error enum. See file header for full semantics.
+  //
+  // Field number 5102347 allocated from the proto custom-option
+  // registry for the brefwiz ecosystem. Drift would be a 0103
+  // amendment, not a code change.
+  repeated string errors = 5102347;
+}

--- a/api-bones-protos/proto/bones/v1/annotations.proto
+++ b/api-bones-protos/proto/bones/v1/annotations.proto
@@ -2,10 +2,8 @@
 //
 // Method-level annotations for service authors.
 //
-// `bones.v1.errors` — the declared error contract for an RPC, per
-// ADR platform/0103. Every RPC in a `wire_surface: proto-source`
-// service must declare the error variants it may return. Variant
-// names are ALL_CAPS_SNAKE strings that reference the service's
+// `bones.v1.errors` — declares the error variants an RPC may return.
+// Variant names are ALL_CAPS_SNAKE strings referencing the service's
 // companion error enum (the enum itself is service-owned; this
 // option just enumerates which variants apply per RPC).
 //
@@ -19,29 +17,9 @@
 //     }
 //   }
 //
-// Consumers of the annotation:
-//
-//   - SDK generators (api-bones-sdk-gen) — emit typed error variants
-//     in the SDK per declared variant; undeclared runtime errors map
-//     to a catch-all `Unknown(google.rpc.Status)` variant.
-//   - `/doc-pipeline` coverage gate (ADR platform/0102) — requires
-//     one `@endpoint:<rpc> @state:<variant>` Gherkin scenario per
-//     declared variant + one for the happy path.
-//   - Runtime error mappers (server-side, optional) — assert at
-//     handler return that any error returned matches a declared
-//     variant; refuse to ship undeclared errors over the wire.
-//
-// Enforcement:
-//
-//   1. Compile-time (preferred): a buf lint rule (or custom protoc
-//      plugin) emits a build error when an RPC in a proto-source
-//      repo has zero `option (bones.v1.errors)` annotations.
-//   2. `make proto-errors-check` (guaranteed floor): parses proto
-//      descriptors and fails on RPCs missing the annotation. Lives
-//      in the api-bones make-include consumed by every service.
-//
-// Allowlist for legitimately error-free RPCs (e.g. Healthz) lives
-// in the service's `buf.yaml` lint config, not here.
+// SDK generators consume the annotation to emit typed per-RPC error
+// surfaces; undeclared runtime errors map to a catch-all variant
+// keyed off `google.rpc.Status`.
 
 syntax = "proto3";
 
@@ -53,9 +31,5 @@ extend google.protobuf.MethodOptions {
   // Declared error variants for this RPC. Variant names are
   // ALL_CAPS_SNAKE and must match a value in the service's
   // companion error enum. See file header for full semantics.
-  //
-  // Field number 5102347 allocated from the proto custom-option
-  // registry for the brefwiz ecosystem. Drift would be a 0103
-  // amendment, not a code change.
   repeated string errors = 5102347;
 }


### PR DESCRIPTION
## Summary

Defines the `bones.v1.errors` MethodOptions extension per ADR platform/0103.

```proto
extend google.protobuf.MethodOptions {
  repeated string errors = 5102347;
}
```

Single declaration site for the typed proto-side error contract. Consumers:
- SDK generators (api-bones-sdk-gen) — emit typed SDK error variants
- `/doc-pipeline` coverage gate (ADR-0102) — requires one `@endpoint @state` scenario per declared variant
- Runtime error mappers (optional, server-side)

## Naming note

ADR-0103 originally specified `package brefwiz.v1`; in implementation we use the existing `bones.v1` package to avoid fragmenting `api-bones-protos`. A companion ADR amendment in `brefwiz-architecture` updates the ADR wording to match.

## Test plan
- [ ] `cd api-bones-protos/proto && buf lint` clean
- [ ] No breaking-change errors on `buf breaking`
- [ ] Field number `5102347` not in use by any existing extension
