### PR TITLE
feat(connect): shared DomainError → ConnectError mapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`connect::domain_error` — shared `DomainError → ConnectError` mapper** (ADR-0096).
+  New module `api_bones::connect::domain_error` (re-exported from `api_bones::connect`) providing:
+  - `DomainErrorKind` — canonical three-variant enum (`NotFound`, `Conflict(String)`, `Internal(String)`)
+  - `IntoDomainErrorKind` — trait for service error types to implement
+  - `domain_to_connect::<E>` — generic mapper; `Internal` logs via `tracing::error!` before returning a safe `ConnectError::internal("internal error")` — detail never surfaced to callers
+
+  **Migration pattern for service authors:**
+
+  1. Implement `IntoDomainErrorKind` on your service's domain error type:
+
+     ```rust
+     use api_bones::connect::{DomainErrorKind, IntoDomainErrorKind};
+
+     impl IntoDomainErrorKind for MyServiceError {
+         fn kind(&self) -> DomainErrorKind {
+             match self {
+                 Self::NotFound => DomainErrorKind::NotFound,
+                 Self::Duplicate(msg) => DomainErrorKind::Conflict(msg.clone()),
+                 Self::Unexpected(msg) => DomainErrorKind::Internal(msg.clone()),
+             }
+         }
+     }
+     ```
+
+  2. Replace hand-rolled mapper functions with `domain_to_connect`:
+
+     ```rust
+     use api_bones::connect::domain_to_connect;
+
+     // before:
+     fn map_err(e: MyServiceError) -> ConnectError { ... }
+
+     // after:
+     store.get(id).await.map_err(|e| domain_to_connect(&e))?;
+     ```
+
+  3. Delete per-service mapper functions and their unit tests — coverage is now in `api-bones`.
+
 ## [6.2.0] — 2026-05-20
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,7 @@ dependencies = [
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
  "utoipa",
  "uuid",
  "validator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ chrono = ["dep:chrono", "utoipa?/chrono"]
 ## Provides chrono_to_timestamp, parse_uuid, build_page (OffsetPage), and
 ## ConnectOptionExt. Activates the uuid and chrono features as side-effects.
 ## Zero impact on consumers who do not declare this feature.
-connect = ["dep:connectrpc", "dep:buffa-types", "uuid", "chrono"]
+connect = ["dep:connectrpc", "dep:buffa-types", "dep:tracing", "uuid", "chrono"]
 http = ["dep:http", "alloc"]
 axum = ["dep:axum", "http", "serde", "std"]
 utoipa = ["dep:utoipa", "std"]
@@ -89,6 +89,7 @@ sha2 = { version = "0.11", optional = true }
 # Mismatch causes type-laundering pain at adapter boundaries (ADR-0096).
 connectrpc  = { version = "0.4", optional = true }
 buffa-types = { version = "0.5", features = ["json"], optional = true }
+tracing     = { version = "0.1", optional = true }
 
 [lints.rust]
 # Allow cfg(coverage) set by cargo-llvm-cov

--- a/src/connect/domain_error.rs
+++ b/src/connect/domain_error.rs
@@ -1,0 +1,142 @@
+use connectrpc::ConnectError;
+
+/// Canonical error-kind shape for domain errors that need to cross the Connect RPC boundary.
+///
+/// Services implementing `IntoDomainErrorKind` on their own error types gain a
+/// zero-boilerplate `domain_to_connect` mapper — no per-service re-implementation
+/// of the `DomainError → ConnectError` translation table (ADR-0096).
+///
+/// # Variants
+///
+/// - `NotFound` — resource absent; maps to `ConnectError::not_found`.
+/// - `Conflict(String)` — state conflict (e.g. duplicate key); maps to
+///   `ConnectError::already_exists`.
+/// - `Internal(String)` — unexpected error; logged via `tracing::error!` then
+///   mapped to `ConnectError::internal` with a generic message (no internal
+///   detail surfaced to callers).
+#[derive(Debug)]
+pub enum DomainErrorKind {
+    NotFound,
+    Conflict(String),
+    Internal(String),
+}
+
+/// Implement this trait on your service's domain error type to unlock the
+/// generic [`domain_to_connect`] mapper.
+///
+/// # Example
+///
+/// ```rust
+/// use api_bones::connect::{DomainErrorKind, IntoDomainErrorKind};
+///
+/// enum MyError {
+///     NotFound,
+///     AlreadyExists(String),
+///     Unexpected(String),
+/// }
+///
+/// impl IntoDomainErrorKind for MyError {
+///     fn kind(&self) -> DomainErrorKind {
+///         match self {
+///             Self::NotFound => DomainErrorKind::NotFound,
+///             Self::AlreadyExists(msg) => DomainErrorKind::Conflict(msg.clone()),
+///             Self::Unexpected(msg) => DomainErrorKind::Internal(msg.clone()),
+///         }
+///     }
+/// }
+/// ```
+pub trait IntoDomainErrorKind {
+    fn kind(&self) -> DomainErrorKind;
+}
+
+/// Map any domain error implementing [`IntoDomainErrorKind`] to a [`ConnectError`].
+///
+/// Variant mapping:
+///
+/// | `DomainErrorKind`  | `ConnectError`             |
+/// |--------------------|----------------------------|
+/// | `NotFound`         | `not_found("not found")`   |
+/// | `Conflict(msg)`    | `already_exists(msg)`      |
+/// | `Internal(detail)` | `internal("internal error")` — detail logged, not surfaced |
+///
+/// Internal errors are logged at `ERROR` level before the `ConnectError` is
+/// returned. The detail string is never forwarded to callers.
+///
+/// # Example
+///
+/// ```rust
+/// use api_bones::connect::{DomainErrorKind, IntoDomainErrorKind, domain_to_connect};
+/// use connectrpc::ConnectError;
+///
+/// struct NotFoundErr;
+/// impl IntoDomainErrorKind for NotFoundErr {
+///     fn kind(&self) -> DomainErrorKind { DomainErrorKind::NotFound }
+/// }
+///
+/// let err: ConnectError = domain_to_connect(&NotFoundErr);
+/// ```
+pub fn domain_to_connect<E: IntoDomainErrorKind>(err: &E) -> ConnectError {
+    match err.kind() {
+        DomainErrorKind::NotFound => ConnectError::not_found("not found"),
+        DomainErrorKind::Conflict(msg) => ConnectError::already_exists(msg),
+        DomainErrorKind::Internal(detail) => {
+            tracing::error!(error = %detail, "internal domain error");
+            ConnectError::internal("internal error")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TestErr(DomainErrorKind);
+
+    impl IntoDomainErrorKind for TestErr {
+        fn kind(&self) -> DomainErrorKind {
+            match &self.0 {
+                DomainErrorKind::NotFound => DomainErrorKind::NotFound,
+                DomainErrorKind::Conflict(s) => DomainErrorKind::Conflict(s.clone()),
+                DomainErrorKind::Internal(s) => DomainErrorKind::Internal(s.clone()),
+            }
+        }
+    }
+
+    fn debug_str(e: &ConnectError) -> String {
+        format!("{e:?}")
+    }
+
+    #[test]
+    fn not_found_maps_to_not_found() {
+        let err = domain_to_connect(&TestErr(DomainErrorKind::NotFound));
+        let s = debug_str(&err);
+        assert!(
+            s.contains("not_found") || s.contains("NotFound"),
+            "expected not_found code, got: {s}"
+        );
+    }
+
+    #[test]
+    fn conflict_maps_to_already_exists() {
+        let err = domain_to_connect(&TestErr(DomainErrorKind::Conflict("dup key".into())));
+        let s = debug_str(&err);
+        assert!(
+            s.contains("already_exists") || s.contains("AlreadyExists"),
+            "expected already_exists code, got: {s}"
+        );
+    }
+
+    #[test]
+    fn internal_maps_to_internal_without_detail() {
+        let err = domain_to_connect(&TestErr(DomainErrorKind::Internal("secret detail".into())));
+        let s = debug_str(&err);
+        assert!(
+            s.contains("internal") || s.contains("Internal"),
+            "expected internal code, got: {s}"
+        );
+        assert!(
+            !s.contains("secret detail"),
+            "internal detail must not be surfaced to caller"
+        );
+    }
+}

--- a/src/connect/mod.rs
+++ b/src/connect/mod.rs
@@ -44,11 +44,13 @@
 //! A CI grep gate (`connect-bones-check`) additionally bans raw
 //! `Uuid::parse_str(` and `Timestamp::from_unix(` calls in adapter modules.
 
+mod domain_error;
 mod ext;
 mod page;
 mod timestamp;
 mod uuid;
 
+pub use domain_error::{DomainErrorKind, IntoDomainErrorKind, domain_to_connect};
 pub use ext::ConnectOptionExt;
 pub use page::{DEFAULT_LIMIT, MAX_LIMIT, OffsetPage, build_offset_page, build_page};
 pub use timestamp::{chrono_opt_to_timestamp, chrono_to_timestamp};


### PR DESCRIPTION
## Summary

- New module `api_bones::connect::domain_error` with `DomainErrorKind` enum, `IntoDomainErrorKind` trait, and `domain_to_connect::<E>` generic mapper (ADR-0096)
- `Internal` variant logs detail via `tracing::error!` before returning safe `ConnectError::internal("internal error")` — nothing internal surfaced to callers
- Unit tests for all three variant mappings (NotFound → not_found, Conflict → already_exists, Internal → internal without detail leak)
- `tracing` added as optional dep gated behind the `connect` feature
- Public re-exports added to `api_bones::connect`
- CHANGELOG `[Unreleased]` section documents new types and migration pattern for service authors

## Test plan

- [x] `ci-test` passes locally (all three variant tests green)
- [x] No `todo!()` / `unimplemented!()` / stubs
- [x] Internal detail not surfaced in `ConnectError` (asserted in test)
- [x] Re-exports present in `src/connect/mod.rs`
- [x] CHANGELOG updated with migration pattern

## Non-goals (per issue)

- No utoipa/HandlerError mapping
- No quorumprofile changes in this PR (migration note in CHANGELOG instead)
- No new variant additions beyond the three specified

Closes #75
