### PR TITLE
chore: release v6.3.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     with:
       # Publish in dependency order: api-bones must land on crates.io before
       # the satellite crates can resolve it.
-      crates: "api-bones api-bones-tower api-bones-reqwest api-bones-progenitor api-bones-sdk-gen api-bones-test api-bones-protos"
+      crates: "api-bones api-bones-connect api-bones-tower api-bones-reqwest api-bones-progenitor api-bones-sdk-gen api-bones-test api-bones-protos"
     secrets:
       cargo-registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
     permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.3.0] — 2026-05-31
+
 ### Added
 
 - **`connect::domain_error` — shared `DomainError → ConnectError` mapper** (ADR-0096).
@@ -46,6 +48,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
      ```
 
   3. Delete per-service mapper functions and their unit tests — coverage is now in `api-bones`.
+
+- **`api-bones-connect` 0.1.0** — new satellite crate re-exporting the full `api_bones::connect` surface.
+  Consumers who prefer a dedicated dependency over enabling the `connect` feature flag on `api-bones`:
+  ```toml
+  api-bones-connect = "0.1"
+  ```
+
+### Changed
+
+- **Dependency bumps** (no public API change):
+  - `connectrpc` 0.4.2 → 0.6.0
+  - `buffa-types` 0.5.2 → 0.6.0
+  - `tokio` 1.51.1 → 1.52.3
+  - `async-nats` 0.47.0 → 0.48.0
+  - `utoipa` 5.4.0 → 5.5.0
+  - `serde_json` 1.0.149 → 1.0.150
+  - `pin-project` 1.1.11 → 1.1.13
+  - `openssl` 0.10.79 → 0.10.80
+  - `actions/checkout` v4 → v6
 
 ## [6.2.0] — 2026-05-20
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-bones"
-version = "6.2.0"
+version = "6.3.0"
 dependencies = [
  "arbitrary",
  "axum",
@@ -116,6 +116,14 @@ dependencies = [
  "utoipa",
  "uuid",
  "validator",
+]
+
+[[package]]
+name = "api-bones-connect"
+version = "0.1.0"
+dependencies = [
+ "api-bones",
+ "connectrpc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     ".",
+    "api-bones-connect",
     "api-bones-tower",
     "api-bones-reqwest",
     "api-bones-progenitor",
@@ -20,7 +21,7 @@ pedantic = { level = "deny", priority = -1 }
 
 [package]
 name = "api-bones"
-version = "6.2.0"
+version = "6.3.0"
 edition = "2024"
 authors = ["Gregoire Salingue"]
 license = "MIT"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 # Makefile for api-bones
 
 .PHONY: help fmt ci-format ci-lint ci-no-std ci-test ci-coverage ci-audit ci-deny build clean \
-	proto-lint proto-breaking ci-release-readiness spec-check
+	proto-lint proto-breaking ci-release-readiness spec-check \
+	ci-build-check sdk-e2e-check sdk-e2e-prebuild
 
 .DEFAULT_GOAL := help
 
@@ -78,6 +79,19 @@ ci-release-readiness: ## CI: `cargo package` every publishable crate with full v
 		cargo package -p "$$crate" --allow-dirty; \
 	done; \
 	echo "==> all publishable crates package-verified."
+
+.PHONY: ci-build-check
+ci-build-check: ## Compile-check all feature combinations
+	cargo check --all-features
+	cargo check --no-default-features
+
+.PHONY: sdk-e2e-check
+sdk-e2e-check: ## No SDK E2E targets for this library crate
+	@echo "sdk-e2e-check: no-op (library crate)"
+
+.PHONY: sdk-e2e-prebuild
+sdk-e2e-prebuild: ## No SDK E2E prebuild for this library crate
+	@echo "sdk-e2e-prebuild: no-op (library crate)"
 
 .PHONY: spec-check
 spec-check: ## L1 ADR-0086: SPEC.md exists and wire_surface is valid

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Makefile for api-bones
 
 .PHONY: help fmt ci-format ci-lint ci-no-std ci-test ci-coverage ci-audit ci-deny build clean \
-	proto-lint proto-breaking ci-release-readiness
+	proto-lint proto-breaking ci-release-readiness spec-check
 
 .DEFAULT_GOAL := help
 
@@ -78,6 +78,17 @@ ci-release-readiness: ## CI: `cargo package` every publishable crate with full v
 		cargo package -p "$$crate" --allow-dirty; \
 	done; \
 	echo "==> all publishable crates package-verified."
+
+.PHONY: spec-check
+spec-check: ## L1 ADR-0086: SPEC.md exists and wire_surface is valid
+	@SPEC=SPEC.md; \
+	VALID="proto-source utoipa-legacy mixed-transition"; \
+	[ -f "$$SPEC" ] || { echo "ERROR: $$SPEC missing (ADR-0086 L1)"; exit 1; }; \
+	WS=$$(awk 'BEGIN{f=0}/^---/{f=!f;next}f&&/^wire_surface:/{print $$2;exit}' "$$SPEC"); \
+	[ -n "$$WS" ] || { echo "ERROR: wire_surface field missing (ADR-0086 L1)"; exit 1; }; \
+	echo "$$VALID" | tr ' ' '\n' | grep -qx "$$WS" \
+		|| { echo "ERROR: wire_surface='$$WS' invalid. Must be one of: $$VALID"; exit 1; }; \
+	echo "spec-check OK: wire_surface=$$WS"
 
 .PHONY: pre-commit
 pre-commit: ci-format ci-lint ci-test ci-changelog ## Run all pre-commit checks (ADR-0021)

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 .PHONY: help fmt ci-format ci-lint ci-no-std ci-test ci-coverage ci-audit ci-deny build clean \
 	proto-lint proto-breaking ci-release-readiness spec-check \
-	ci-build-check sdk-e2e-check sdk-e2e-prebuild
+	ci-build-check sdk-e2e-check sdk-e2e-prebuild sc-001-check
 
 .DEFAULT_GOAL := help
 
@@ -79,6 +79,12 @@ ci-release-readiness: ## CI: `cargo package` every publishable crate with full v
 		cargo package -p "$$crate" --allow-dirty; \
 	done; \
 	echo "==> all publishable crates package-verified."
+
+.PHONY: sc-001-check
+sc-001-check: ## SC-001: ban tracing_subscriber::fmt in main/bin entry points
+	@grep -rn 'tracing_subscriber::fmt().*try_init\|tracing_subscriber::fmt::Subscriber.*try_init' \
+	  src/main.rs src/bin/*.rs 2>/dev/null \
+	  && (echo 'SC-001 violation: use otel-bootstrap via service-kit instead' && exit 1) || true
 
 .PHONY: ci-build-check
 ci-build-check: ## Compile-check all feature combinations

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@
 
 .PHONY: help fmt ci-format ci-lint ci-no-std ci-test ci-coverage ci-audit ci-deny build clean \
 	proto-lint proto-breaking ci-release-readiness spec-check \
-	ci-build-check sdk-e2e-check sdk-e2e-prebuild sc-001-check
+	ci-build-check sdk-e2e-check sdk-e2e-prebuild sc-001-check \
+	lockfile ci-lockfile-diff
 
 .DEFAULT_GOAL := help
 
@@ -79,6 +80,18 @@ ci-release-readiness: ## CI: `cargo package` every publishable crate with full v
 		cargo package -p "$$crate" --allow-dirty; \
 	done; \
 	echo "==> all publishable crates package-verified."
+
+.PHONY: lockfile
+lockfile: ## Regenerate Cargo.lock
+	cargo generate-lockfile
+
+.PHONY: ci-lockfile-diff
+ci-lockfile-diff: ## Assert committed Cargo.lock matches resolved lock
+	@cargo generate-lockfile
+	@if ! git diff --quiet Cargo.lock; then \
+	  echo 'ERROR: Cargo.lock is out of date. Run: make lockfile && git add Cargo.lock'; \
+	  git diff Cargo.lock; exit 1; \
+	fi
 
 .PHONY: sc-001-check
 sc-001-check: ## SC-001: ban tracing_subscriber::fmt in main/bin entry points

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,8 @@
+---
+wire_surface: proto-source
+---
+
+# api-bones
+
+Library crate. Wire surface is defined by the proto schemas in `api-bones-protos`
+(canonical proto-source per ADR-0085). No HTTP handler surface owned by this crate.

--- a/api-bones-connect/Cargo.toml
+++ b/api-bones-connect/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "api-bones-connect"
+version = "0.1.0"
+edition = "2024"
+authors = ["Gregoire Salingue"]
+license = "MIT"
+description = "Connect RPC adapter primitives for api-bones services (ADR-0096)"
+repository = "https://github.com/brefwiz/api-bones"
+homepage = "https://github.com/brefwiz/api-bones"
+documentation = "https://docs.rs/api-bones-connect"
+readme = "README.md"
+keywords = ["connect", "grpc", "rpc", "protobuf", "api-bones"]
+categories = ["web-programming::http-server", "api-bindings", "network-programming"]
+rust-version = "1.85"
+
+[dependencies]
+api-bones = { version = "6.3", path = "..", default-features = false, features = ["connect"] }
+connectrpc = { version = "0.6", optional = false }
+
+[lints]
+workspace = true

--- a/api-bones-connect/src/lib.rs
+++ b/api-bones-connect/src/lib.rs
@@ -1,0 +1,21 @@
+//! Connect RPC adapter primitives for api-bones services (ADR-0096).
+//!
+//! This crate re-exports the [`api_bones::connect`] module surface for
+//! consumers who want a dedicated dependency rather than enabling the
+//! `connect` feature on `api-bones` directly.
+//!
+//! # Usage
+//!
+//! ```toml
+//! [dependencies]
+//! api-bones-connect = "0.1"
+//! ```
+//!
+//! ```rust,ignore
+//! use api_bones_connect::{
+//!     DomainErrorKind, IntoDomainErrorKind, domain_to_connect,
+//!     chrono_to_timestamp, parse_uuid, build_page, ConnectOptionExt as _,
+//! };
+//! ```
+
+pub use api_bones::connect::*;

--- a/src/net/client_ip.rs
+++ b/src/net/client_ip.rs
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: MIT
+//! Effective client IP resolver — rightmost-untrusted XFF algorithm (RFC 7239 §5.2).
+//!
+//! # Algorithm
+//!
+//! 1. Read the peer socket address from the [`axum::extract::ConnectInfo<SocketAddr>`]
+//!    request extension. If absent (e.g. test transports without `ConnectInfo`),
+//!    return `None`.
+//! 2. If the peer IP is **not** inside any `trusted_cidrs`, return it immediately —
+//!    XFF is ignored to prevent spoofing.
+//! 3. If the peer IP **is** trusted, walk `X-Forwarded-For` right → left, skipping
+//!    every IP that is also trusted; return the first untrusted IP found.
+//! 4. Fall back to the peer IP when XFF is absent, all-trusted, or malformed.
+//!
+//! Pass an empty `trusted_cidrs` slice to disable XFF inspection entirely (safe
+//! default — equivalent to returning the bare peer IP).
+//!
+//! # Example
+//!
+//! ```rust
+//! use api_bones::net::client_ip;
+//! use ipnet::IpNet;
+//! use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+//!
+//! let trusted: Vec<IpNet> = vec!["127.0.0.1/8".parse().unwrap()];
+//!
+//! // Build a minimal request with ConnectInfo + XFF.
+//! let peer: SocketAddr = "127.0.0.1:4000".parse().unwrap();
+//! let mut req = http::Request::new(());
+//! req.extensions_mut()
+//!     .insert(axum::extract::ConnectInfo(peer));
+//! req.headers_mut().insert(
+//!     "x-forwarded-for",
+//!     "203.0.113.1".parse().unwrap(),
+//! );
+//!
+//! let ip = client_ip::resolve(&req, &trusted);
+//! assert_eq!(ip, Some(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 1))));
+//! ```
+
+use axum::extract::ConnectInfo;
+use ipnet::IpNet;
+use std::net::{IpAddr, SocketAddr};
+
+/// Resolve the effective client IP for `req` using the rightmost-untrusted
+/// XFF algorithm (RFC 7239 §5.2).
+///
+/// See the [module documentation](self) for the full algorithm description.
+#[must_use]
+pub fn resolve<B>(req: &http::Request<B>, trusted_cidrs: &[IpNet]) -> Option<IpAddr> {
+    let peer_addr = req
+        .extensions()
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|ci| ci.0)?;
+
+    let peer_ip = peer_addr.ip();
+
+    if !is_trusted(peer_ip, trusted_cidrs) {
+        return Some(peer_ip);
+    }
+
+    // Peer is trusted — inspect XFF.
+    let xff_value = req.headers().get("x-forwarded-for")?;
+    let xff_str = std::str::from_utf8(xff_value.as_bytes()).ok()?;
+
+    // Walk right → left; first untrusted IP wins.
+    for part in xff_str.rsplit(',') {
+        let trimmed = part.trim();
+        if let Ok(ip) = trimmed.parse::<IpAddr>() {
+            if !is_trusted(ip, trusted_cidrs) {
+                return Some(ip);
+            }
+        }
+        // Malformed token — skip (treat as trusted to be conservative, keep walking).
+    }
+
+    // All XFF entries were trusted (or XFF was empty / all-malformed) → fall back to peer.
+    Some(peer_ip)
+}
+
+fn is_trusted(ip: IpAddr, cidrs: &[IpNet]) -> bool {
+    cidrs.iter().any(|net| net.contains(&ip))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::Ipv4Addr;
+
+    fn make_req(peer: &str, xff: Option<&str>) -> http::Request<()> {
+        let peer_addr: SocketAddr = peer.parse().unwrap();
+        let mut req = http::Request::new(());
+        req.extensions_mut()
+            .insert(ConnectInfo::<SocketAddr>(peer_addr));
+        if let Some(xff_val) = xff {
+            req.headers_mut()
+                .insert("x-forwarded-for", xff_val.parse().unwrap());
+        }
+        req
+    }
+
+    fn trusted() -> Vec<IpNet> {
+        vec!["10.0.0.0/8".parse().unwrap(), "192.168.0.0/16".parse().unwrap()]
+    }
+
+    /// ConnectInfo absent → None.
+    #[test]
+    fn no_connect_info_returns_none() {
+        let req = http::Request::new(());
+        assert_eq!(resolve(&req, &trusted()), None);
+    }
+
+    /// Peer not in trusted CIDR → peer IP returned (XFF ignored).
+    #[test]
+    fn peer_not_trusted_returns_peer() {
+        let req = make_req("203.0.113.5:1234", Some("1.2.3.4"));
+        let ip = resolve(&req, &trusted()).unwrap();
+        assert_eq!(ip, IpAddr::V4(Ipv4Addr::new(203, 0, 113, 5)));
+    }
+
+    /// Peer trusted + XFF has untrusted entry → rightmost untrusted wins.
+    #[test]
+    fn peer_trusted_xff_rightmost_untrusted() {
+        // XFF: "1.2.3.4, 10.0.0.2" — rightmost is trusted, next is untrusted.
+        let req = make_req("192.168.1.1:4000", Some("203.0.113.1, 10.0.0.2"));
+        let ip = resolve(&req, &trusted()).unwrap();
+        // Walking right → left: 10.0.0.2 is trusted (skip), 203.0.113.1 is untrusted (win).
+        assert_eq!(ip, IpAddr::V4(Ipv4Addr::new(203, 0, 113, 1)));
+    }
+
+    /// Peer trusted + XFF all trusted → fallback to peer.
+    #[test]
+    fn peer_trusted_xff_all_trusted_returns_peer() {
+        let req = make_req("10.0.0.1:80", Some("10.0.0.2, 10.0.0.3"));
+        let ip = resolve(&req, &trusted()).unwrap();
+        assert_eq!(ip, IpAddr::V4(Ipv4Addr::from([10, 0, 0, 1])));
+    }
+
+    /// Malformed XFF (non-IP tokens) → fallback to peer.
+    #[test]
+    fn malformed_xff_returns_peer() {
+        let req = make_req("192.168.1.5:9000", Some("not-an-ip, also-bad"));
+        let ip = resolve(&req, &trusted()).unwrap();
+        assert_eq!(ip, IpAddr::V4(Ipv4Addr::new(192, 168, 1, 5)));
+    }
+}

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+//! Network-level request primitives.
+//!
+//! Gated by the `axum` feature. Provides utilities for inspecting connection
+//! metadata attached to incoming [`http::Request`]s.
+
+pub mod client_ip;


### PR DESCRIPTION
## Summary

- Bumps `api-bones` to **6.3.0**
- Adds **`api-bones-connect` 0.1.0** satellite crate (re-exports `api_bones::connect` surface)
- Adds `api-bones-connect` to `release.yml` crates publish list
- Collapses CHANGELOG `[Unreleased]` into `[6.3.0]` entry including dep bumps from #77
- Adds `SPEC.md` (`wire_surface: proto-source`) + `spec-check` / `ci-build-check` / `lockfile` Makefile targets

On merge CI will auto-tag `v6.3.0` and publish all crates to crates.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)