### PR TITLE
fix(connect): add std to connect feature — no_std publish fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ chrono = ["dep:chrono", "utoipa?/chrono"]
 ## Provides chrono_to_timestamp, parse_uuid, build_page (OffsetPage), and
 ## ConnectOptionExt. Activates the uuid and chrono features as side-effects.
 ## Zero impact on consumers who do not declare this feature.
-connect = ["dep:connectrpc", "dep:buffa-types", "dep:tracing", "uuid", "chrono"]
+connect = ["dep:connectrpc", "dep:buffa-types", "dep:tracing", "uuid", "chrono", "std"]
 http = ["dep:http", "alloc"]
 axum = ["dep:axum", "http", "serde", "std"]
 utoipa = ["dep:utoipa", "std"]


### PR DESCRIPTION
The `connect` feature uses `String`, `format!`, and `ToOwned::to_owned` which require `alloc`/`std`. Without this dependency, `cargo publish` compiles the tarball without `std` and fails.

Fix: add `"std"` to the `connect` feature deps in `Cargo.toml`. Connect RPC is inherently `std`-only (HTTP stack, async runtime) so this is correct semantically. `no_std` consumers who don't enable `connect` are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)