### PR TITLE
feat(connect): add invalid_field, check_if_match, etag, parse_rfc3339, encode_json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.5.0] — 2026-06-02
+
+### Added
+
+- **`connect` module: validation and serialization helpers** — `invalid_field` validation builder, `check_if_match` for conditional processing, `etag` generation, `parse_rfc3339` for timestamp parsing, and `encode_json` for serialization (ADR brefwiz-architecture#226).
+- **`connect` module: usage examples and documentation** — Added examples demonstrating the new connect primitives.
+
+### Changed
+
+- Code style formatting alignment via rustfmt.
+
+## [6.4.0] — 2026-06-02
+
+### Added
+
+- **`connect` module: validation and serialization helpers** (ADR brefwiz-architecture#226).
+  New utilities for wire protocol helpers: `invalid_field` validation builder, `check_if_match` for conditional processing, `etag` generation, `parse_rfc3339` for timestamp parsing, and `encode_json` for serialization.
+
 ## [6.3.1] — 2026-05-31
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-bones"
-version = "6.3.1"
+version = "6.5.0"
 dependencies = [
  "arbitrary",
  "axum",
@@ -435,9 +435,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 
 [[package]]
 name = "block-buffer"
@@ -1954,9 +1954,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
 
 [[package]]
 name = "matchit"
@@ -2888,9 +2888,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ pedantic = { level = "deny", priority = -1 }
 
 [package]
 name = "api-bones"
-version = "6.3.1"
+version = "6.5.0"
 edition = "2024"
 authors = ["Gregoire Salingue"]
 license = "MIT"
@@ -52,7 +52,7 @@ chrono = ["dep:chrono", "utoipa?/chrono"]
 ## Provides chrono_to_timestamp, parse_uuid, build_page (OffsetPage), and
 ## ConnectOptionExt. Activates the uuid and chrono features as side-effects.
 ## Zero impact on consumers who do not declare this feature.
-connect = ["dep:connectrpc", "dep:buffa-types", "dep:tracing", "uuid", "chrono", "std"]
+connect = ["dep:connectrpc", "dep:buffa-types", "dep:tracing", "dep:serde", "dep:serde_json", "uuid", "chrono", "std"]
 http = ["dep:http", "alloc"]
 axum = ["dep:axum", "http", "serde", "std"]
 utoipa = ["dep:utoipa", "std"]

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ What's specific to api-bones is the opinion: one crate, bundled surface, strict 
 
 ```toml
 [dependencies]
-api-bones = "4.0"
+api-bones = "6.5.0"
 ```
 
 ## Use cases
@@ -254,10 +254,10 @@ All implement the `HeaderId` trait (`as_str()`, `header_name()`).
 
 ```toml
 # no_std + alloc (WASM, embedded with allocator)
-api-bones = { version = "4", default-features = false, features = ["alloc"] }
+api-bones = { version = "6.5.0", default-features = false, features = ["alloc"] }
 
 # pure no_std (core types only)
-api-bones = { version = "4", default-features = false }
+api-bones = { version = "6.5.0", default-features = false }
 ```
 
 ## License

--- a/api-bones-connect/Cargo.toml
+++ b/api-bones-connect/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["web-programming::http-server", "api-bindings", "network-programmi
 rust-version = "1.85"
 
 [dependencies]
-api-bones = { version = "6.5", path = "..", default-features = false, features = ["connect"] }
+api-bones = { version = "6", path = "..", default-features = false, features = ["connect"] }
 connectrpc = { version = "0.6", optional = false }
 
 [lints]

--- a/api-bones-connect/Cargo.toml
+++ b/api-bones-connect/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["web-programming::http-server", "api-bindings", "network-programmi
 rust-version = "1.85"
 
 [dependencies]
-api-bones = { version = "6.3", path = "..", default-features = false, features = ["connect"] }
+api-bones = { version = "6.5", path = "..", default-features = false, features = ["connect"] }
 connectrpc = { version = "0.6", optional = false }
 
 [lints]

--- a/api-bones-reqwest/Cargo.toml
+++ b/api-bones-reqwest/Cargo.toml
@@ -26,7 +26,7 @@ rust-version = "1.85"
 uuid = ["dep:uuid", "api-bones/uuid"]
 
 [dependencies]
-api-bones = { path = "..", version = "6.0", default-features = false, features = ["std", "serde"] }
+api-bones = { path = "..", version = "6.5", default-features = false, features = ["std", "serde"] }
 reqwest = { version = "0.13", default-features = false, features = ["json"] }
 uuid = { version = "1.23", optional = true }
 serde = { version = "1.0", features = ["derive"] }

--- a/api-bones-reqwest/Cargo.toml
+++ b/api-bones-reqwest/Cargo.toml
@@ -26,7 +26,7 @@ rust-version = "1.85"
 uuid = ["dep:uuid", "api-bones/uuid"]
 
 [dependencies]
-api-bones = { path = "..", version = "6.5", default-features = false, features = ["std", "serde"] }
+api-bones = { path = "..", version = "6", default-features = false, features = ["std", "serde"] }
 reqwest = { version = "0.13", default-features = false, features = ["json"] }
 uuid = { version = "1.23", optional = true }
 serde = { version = "1.0", features = ["derive"] }

--- a/api-bones-test/Cargo.toml
+++ b/api-bones-test/Cargo.toml
@@ -38,7 +38,7 @@ nats = [
 ]
 
 [dependencies]
-api-bones = { path = "..", version = "6.5", features = ["chrono", "uuid", "serde", "std"] }
+api-bones = { path = "..", version = "6", features = ["chrono", "uuid", "serde", "std"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 uuid = { version = "1.23", features = ["v4"] }

--- a/api-bones-test/Cargo.toml
+++ b/api-bones-test/Cargo.toml
@@ -38,7 +38,7 @@ nats = [
 ]
 
 [dependencies]
-api-bones = { path = "..", version = "6.0", features = ["chrono", "uuid", "serde", "std"] }
+api-bones = { path = "..", version = "6.5", features = ["chrono", "uuid", "serde", "std"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 uuid = { version = "1.23", features = ["v4"] }

--- a/api-bones-tower/Cargo.toml
+++ b/api-bones-tower/Cargo.toml
@@ -28,7 +28,7 @@ uuid = ["api-bones/uuid"]
 chrono = ["api-bones/chrono"]
 
 [dependencies]
-api-bones = { version = "6.0", path = "..", default-features = false, features = ["std", "serde"] }
+api-bones = { version = "6.5", path = "..", default-features = false, features = ["std", "serde"] }
 tower = { version = "0.5", features = ["util"] }
 http = { version = "1.0" }
 http-body = { version = "1.0" }

--- a/api-bones-tower/Cargo.toml
+++ b/api-bones-tower/Cargo.toml
@@ -28,7 +28,7 @@ uuid = ["api-bones/uuid"]
 chrono = ["api-bones/chrono"]
 
 [dependencies]
-api-bones = { version = "6.5", path = "..", default-features = false, features = ["std", "serde"] }
+api-bones = { version = "6", path = "..", default-features = false, features = ["std", "serde"] }
 tower = { version = "0.5", features = ["util"] }
 http = { version = "1.0" }
 http-body = { version = "1.0" }

--- a/examples/connect_adapter.rs
+++ b/examples/connect_adapter.rs
@@ -13,9 +13,8 @@ struct QuantityRule {
 #[cfg(feature = "connect")]
 fn main() {
     use api_bones::connect::{
-        ConnectOptionExt as _, build_page, chrono_opt_to_timestamp,
-        chrono_to_timestamp, encode_json, etag_from_updated_at, invalid_field, parse_rfc3339,
-        parse_uuid,
+        ConnectOptionExt as _, build_page, chrono_opt_to_timestamp, chrono_to_timestamp,
+        encode_json, etag_from_updated_at, invalid_field, parse_rfc3339, parse_uuid,
     };
 
     // ── Timestamp conversion ───────────────────────────────────────────────

--- a/examples/connect_adapter.rs
+++ b/examples/connect_adapter.rs
@@ -6,7 +6,9 @@
 #[cfg(feature = "connect")]
 fn main() {
     use api_bones::connect::{
-        ConnectOptionExt as _, build_page, chrono_opt_to_timestamp, chrono_to_timestamp, parse_uuid,
+        ConnectOptionExt as _, build_page, check_if_match, chrono_opt_to_timestamp,
+        chrono_to_timestamp, encode_json, etag_from_updated_at, invalid_field, parse_rfc3339,
+        parse_uuid,
     };
 
     // ── Timestamp conversion ───────────────────────────────────────────────
@@ -54,6 +56,42 @@ fn main() {
 
     let missing: Result<Option<&str>, connectrpc::ConnectError> = Ok(None);
     assert!(missing.or_not_found("record not found").is_err());
+
+    // ── invalid_field ──────────────────────────────────────────────────────
+    let err = invalid_field("org_id");
+    println!("invalid_field: {:?}", err.code);
+
+    // ── encode_json ────────────────────────────────────────────────────────
+    #[derive(serde::Serialize)]
+    struct QuantityRule {
+        kind: &'static str,
+        value: u32,
+    }
+    let json = encode_json(
+        &QuantityRule {
+            kind: "fixed",
+            value: 2,
+        },
+        "quantity_rule",
+    )
+    .unwrap();
+    assert_eq!(json, r#"{"kind":"fixed","value":2}"#);
+    println!("encode_json: {json}");
+
+    // ── parse_rfc3339 ──────────────────────────────────────────────────────
+    let dt = parse_rfc3339("2024-01-15T10:00:00Z", "starts_at").unwrap();
+    println!("parse_rfc3339: {dt}");
+    assert!(parse_rfc3339("not-a-date", "starts_at").is_err());
+
+    // ── etag_from_updated_at ───────────────────────────────────────────────
+    let etag = etag_from_updated_at(chrono::Utc::now());
+    assert!(etag.starts_with("W/\""), "etag={etag}");
+    println!("etag: {etag}");
+
+    // ── check_if_match ─────────────────────────────────────────────────────
+    // check_if_match requires a RequestContext which is only available inside a
+    // live connect handler; the behaviour is validated in unit tests in
+    // src/connect/etag.rs. See those tests for the four-case breakdown.
 
     println!("All connect adapter primitives OK");
 }

--- a/examples/connect_adapter.rs
+++ b/examples/connect_adapter.rs
@@ -4,9 +4,16 @@
 //!   cargo run --example `connect_adapter` --features connect
 
 #[cfg(feature = "connect")]
+#[derive(serde::Serialize)]
+struct QuantityRule {
+    kind: &'static str,
+    value: u32,
+}
+
+#[cfg(feature = "connect")]
 fn main() {
     use api_bones::connect::{
-        ConnectOptionExt as _, build_page, check_if_match, chrono_opt_to_timestamp,
+        ConnectOptionExt as _, build_page, chrono_opt_to_timestamp,
         chrono_to_timestamp, encode_json, etag_from_updated_at, invalid_field, parse_rfc3339,
         parse_uuid,
     };
@@ -62,11 +69,6 @@ fn main() {
     println!("invalid_field: {:?}", err.code);
 
     // ── encode_json ────────────────────────────────────────────────────────
-    #[derive(serde::Serialize)]
-    struct QuantityRule {
-        kind: &'static str,
-        value: u32,
-    }
     let json = encode_json(
         &QuantityRule {
             kind: "fixed",

--- a/quorate-ci-28-1-e2e-rust-checkout
+++ b/quorate-ci-28-1-e2e-rust-checkout
@@ -1,0 +1,3 @@
+Start cloning https://git.brefwiz.com/brefwiz/quorate.git
+Checkout branch chore/bump-api-bones-6.3.1
+Checkout completed

--- a/src/connect/etag.rs
+++ b/src/connect/etag.rs
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: LicenseRef-Brefwiz-Proprietary
+// ETag / If-Match helpers for Connect RPC adapters.
+
+use chrono::{DateTime, Utc};
+use connectrpc::{ConnectError, ErrorCode, RequestContext};
+
+/// Generate a weak `ETag` from an `updated_at` timestamp.
+/// Format: `W/"<unix_ms>"` — mirrors `service_kit::etag::etag_from_updated_at`.
+#[must_use]
+pub fn etag_from_updated_at(updated_at: DateTime<Utc>) -> String {
+    format!("W/\"{}\"", updated_at.timestamp_millis())
+}
+
+/// Enforce the `If-Match` precondition on a Connect request context.
+/// - Header absent or empty → `FailedPrecondition` ("If-Match header required")
+/// - `"*"` → Ok(()) (unconditional write)
+/// - value matches `current_etag` → Ok(())
+/// - mismatch → Aborted ("`ETag` mismatch")
+pub fn check_if_match(ctx: &RequestContext, current_etag: &str) -> Result<(), ConnectError> {
+    let header = ctx
+        .header("if-match")
+        .and_then(|v| v.to_str().ok())
+        .map(str::trim);
+    match header {
+        None | Some("") => Err(ConnectError::new(
+            ErrorCode::FailedPrecondition,
+            "If-Match header required",
+        )),
+        Some("*") => Ok(()),
+        Some(v) if v == current_etag => Ok(()),
+        Some(_) => Err(ConnectError::new(ErrorCode::Aborted, "ETag mismatch")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone as _;
+    use connectrpc::ErrorCode;
+    use http::HeaderMap;
+
+    fn ctx_with_if_match(value: &str) -> RequestContext {
+        let mut headers = HeaderMap::new();
+        headers.insert("if-match", value.parse().unwrap());
+        RequestContext::new(headers)
+    }
+
+    fn ctx_empty() -> RequestContext {
+        RequestContext::new(HeaderMap::new())
+    }
+
+    #[test]
+    fn etag_format() {
+        let ts = Utc.timestamp_millis_opt(1_700_000_000_000).unwrap();
+        assert_eq!(etag_from_updated_at(ts), r#"W/"1700000000000""#);
+    }
+
+    #[test]
+    fn check_if_match_absent_header() {
+        let err = check_if_match(&ctx_empty(), r#"W/"123""#).unwrap_err();
+        assert_eq!(err.code, ErrorCode::FailedPrecondition);
+    }
+
+    #[test]
+    fn check_if_match_empty_header() {
+        let err = check_if_match(&ctx_with_if_match(""), r#"W/"123""#).unwrap_err();
+        assert_eq!(err.code, ErrorCode::FailedPrecondition);
+    }
+
+    #[test]
+    fn check_if_match_wildcard() {
+        check_if_match(&ctx_with_if_match("*"), r#"W/"123""#).unwrap();
+    }
+
+    #[test]
+    fn check_if_match_exact_match() {
+        check_if_match(&ctx_with_if_match(r#"W/"123""#), r#"W/"123""#).unwrap();
+    }
+
+    #[test]
+    fn check_if_match_mismatch() {
+        let err = check_if_match(&ctx_with_if_match(r#"W/"999""#), r#"W/"123""#).unwrap_err();
+        assert_eq!(err.code, ErrorCode::Aborted);
+    }
+}

--- a/src/connect/mod.rs
+++ b/src/connect/mod.rs
@@ -11,9 +11,11 @@
 //! ```rust,ignore
 //! use api_bones::connect::{
 //!     chrono_to_timestamp, chrono_opt_to_timestamp,
-//!     parse_uuid,
+//!     parse_uuid, parse_rfc3339,
 //!     build_page, build_offset_page, OffsetPage,
 //!     ConnectOptionExt as _,
+//!     invalid_field, encode_json,
+//!     check_if_match, etag_from_updated_at,
 //! };
 //!
 //! // Timestamp conversion
@@ -22,12 +24,25 @@
 //! // UUID parsing with field attribution in the error message
 //! let org_id = parse_uuid(request.org_id, "org_id")?;
 //!
+//! // RFC-3339 datetime parsing
+//! let starts_at = parse_rfc3339(request.starts_at, "starts_at")?;
+//!
 //! // Pagination — OffsetPage has a private constructor; build_page is the only entry point
 //! let page = build_page(req.page.limit, req.page.offset, items.len(), total);
 //! let (total_count, has_more, limit, offset) = page.into_parts();
 //!
 //! // Option → not_found
 //! let record = store.get(id).await.map_err(core_to_connect)?.or_not_found("not found")?;
+//!
+//! // Build InvalidArgument for a named field
+//! let err = invalid_field("quantity_rule");
+//!
+//! // Serialize a domain type to a JSON string for an opaque proto field
+//! let json = encode_json(&quantity_rule, "quantity_rule")?;
+//!
+//! // ETag / If-Match — generate and enforce optimistic-concurrency headers
+//! let etag = etag_from_updated_at(record.updated_at);
+//! check_if_match(&ctx, &etag)?; // FailedPrecondition if header absent, Aborted on mismatch
 //! ```
 //!
 //! # Enforcement (ADR-0096)
@@ -45,13 +60,64 @@
 //! `Uuid::parse_str(` and `Timestamp::from_unix(` calls in adapter modules.
 
 mod domain_error;
+mod etag;
 mod ext;
 mod page;
+mod parse;
 mod timestamp;
 mod uuid;
 
 pub use domain_error::{DomainErrorKind, IntoDomainErrorKind, domain_to_connect};
+pub use etag::{check_if_match, etag_from_updated_at};
 pub use ext::ConnectOptionExt;
 pub use page::{DEFAULT_LIMIT, MAX_LIMIT, OffsetPage, build_offset_page, build_page};
+pub use parse::parse_rfc3339;
 pub use timestamp::{chrono_opt_to_timestamp, chrono_to_timestamp};
 pub use uuid::parse_uuid;
+
+/// Build an `InvalidArgument` `ConnectError` attributing the error to a named request field.
+#[must_use]
+pub fn invalid_field(field: &str) -> connectrpc::ConnectError {
+    connectrpc::ConnectError::new(
+        connectrpc::ErrorCode::InvalidArgument,
+        format!("invalid `{field}`"),
+    )
+}
+
+/// Serialize a value to a JSON string for use in opaque proto string fields.
+/// Returns `Internal` if serialization fails (rare — only on non-serializable types).
+pub fn encode_json<T: serde::Serialize>(
+    v: &T,
+    what: &str,
+) -> Result<String, connectrpc::ConnectError> {
+    serde_json::to_string(v).map_err(|e| {
+        connectrpc::ConnectError::new(
+            connectrpc::ErrorCode::Internal,
+            format!("serialize {what}: {e}"),
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use connectrpc::ErrorCode;
+
+    #[test]
+    fn invalid_field_code_and_message() {
+        let err = invalid_field("org_id");
+        assert_eq!(err.code, ErrorCode::InvalidArgument);
+        let msg = err.message.as_deref().unwrap_or("");
+        assert!(msg.contains("org_id"), "message: {msg}");
+    }
+
+    #[test]
+    fn encode_json_simple_struct() {
+        #[derive(serde::Serialize)]
+        struct Foo {
+            bar: u32,
+        }
+        let result = encode_json(&Foo { bar: 42 }, "foo").unwrap();
+        assert_eq!(result, r#"{"bar":42}"#);
+    }
+}

--- a/src/connect/parse.rs
+++ b/src/connect/parse.rs
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: LicenseRef-Brefwiz-Proprietary
+// Parsing helpers for Connect RPC adapters.
+
+use chrono::{DateTime, Utc};
+use connectrpc::ConnectError;
+
+/// Parse an RFC-3339 datetime string, returning `InvalidArgument` with field attribution on failure.
+pub fn parse_rfc3339(s: &str, field: &str) -> Result<DateTime<Utc>, ConnectError> {
+    DateTime::parse_from_rfc3339(s)
+        .map(|dt| dt.with_timezone(&Utc))
+        .map_err(|_| crate::connect::invalid_field(field))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use connectrpc::ErrorCode;
+
+    #[test]
+    fn parse_valid_rfc3339() {
+        let dt = parse_rfc3339("2024-01-15T10:30:00Z", "start_at").unwrap();
+        assert_eq!(dt.timestamp(), 1_705_314_600);
+    }
+
+    #[test]
+    fn parse_invalid_returns_invalid_argument() {
+        let err = parse_rfc3339("not-a-date", "start_at").unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidArgument);
+    }
+
+    #[test]
+    fn parse_with_offset() {
+        let dt = parse_rfc3339("2024-01-15T10:30:00+02:00", "end_at").unwrap();
+        assert_eq!(dt.timestamp(), 1_705_307_400);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `invalid_field(field)` — builds `InvalidArgument` `ConnectError` with field attribution
- Adds `encode_json(v, what)` — serializes to JSON string for opaque proto string fields, returns `Internal` on failure
- Adds `src/connect/etag.rs` — `etag_from_updated_at` (weak ETag from `updated_at`) and `check_if_match` (enforces `If-Match` precondition: absent→`FailedPrecondition`, `"*"`→ok, match→ok, mismatch→`Aborted`)
- Adds `src/connect/parse.rs` — `parse_rfc3339` (RFC-3339 string → `DateTime<Utc>`, `InvalidArgument` on failure)
- Wires `serde`/`serde_json` into the `connect` feature (were previously only under `serde` feature)
- Covers all new primitives with unit tests (1048 tests pass)

Closes brefwiz-architecture#226

## Test plan

- [x] `make ci-lint` passes (clippy `-D warnings` + pedantic)
- [x] `make ci-test` passes (1048/1048)
- [x] `make ci-format` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)