### PR TITLE
chore(api-bones-test): 6.5.1 — publish the 6.x-compatible test crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,7 +165,7 @@ dependencies = [
 
 [[package]]
 name = "api-bones-test"
-version = "5.0.0"
+version = "6.5.1"
 dependencies = [
  "api-bones",
  "async-nats",

--- a/api-bones-test/Cargo.toml
+++ b/api-bones-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api-bones-test"
-version = "5.0.0"
+version = "6.5.1"
 edition = "2024"
 authors = ["Gregoire Salingue"]
 license = "MIT"


### PR DESCRIPTION
## Summary

api-bones-test stayed at 5.0.0 on crates.io while depending on api-bones 6 in-repo — consumers pinning api-bones =6.x can't resolve a matching test crate (quorumauth's service-kit 4.42 migration is blocked on it). Version-only bump to 6.5.1; the shared release workflow skips already-published crates, so tagging v6.5.1 publishes just this one.

## Test plan
- [x] ci-lint green locally
- [ ] CI green; tag v6.5.1 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
