### PR TITLE
fix(propagation): opentelemetry feature requires std; bump 6.7.1 patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.7.1] — 2026-07-18
+
+### Fixed
+
+- **`opentelemetry` feature now requires `std`.** The `opentelemetry` crate is
+  not `no_std`-compatible; the feature previously omitted the `std` requirement
+  present on every other std-only feature (`connect`, `axum`, `utoipa`, ...),
+  which broke `no_default_features + alloc + opentelemetry` builds (the exact
+  combination `sealwiz-sdk` and `brefwiz-spiffe`'s SDKs use) with an unresolved
+  `String` type in `propagation.rs`.
+
 ## [6.7.0] — 2026-07-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "api-bones"
-version = "6.7.0"
+version = "6.7.1"
 dependencies = [
  "arbitrary",
  "axum",
@@ -4299,9 +4299,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4312,14 +4312,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.8",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ pedantic = { level = "deny", priority = -1 }
 
 [package]
 name = "api-bones"
-version = "6.7.0"
+version = "6.7.1"
 edition = "2024"
 authors = ["Gregoire Salingue"]
 license = "MIT"
@@ -67,8 +67,9 @@ schemars = ["dep:schemars", "schemars/uuid1", "schemars/chrono04", "std"]
 hmac = ["base64", "alloc", "dep:hmac", "dep:sha2"]
 ## Enables OpenTelemetry trace context propagation helpers for SDK clients.
 ## Provides `inject_current` for injecting the active span context into HTTP headers.
-## Requires `http` and `opentelemetry` (SDK is only needed for tests).
-opentelemetry = ["http", "dep:opentelemetry"]
+## Requires `http`, `std` (the `opentelemetry` crate is not no_std-compatible),
+## and `opentelemetry` (SDK is only needed for tests).
+opentelemetry = ["http", "std", "dep:opentelemetry"]
 
 [dependencies]
 thiserror = { version = "2", default-features = false }


### PR DESCRIPTION
## Summary

Fixes a build break in the just-released `opentelemetry` feature (6.7.0): the feature omitted `std` from its requirements (every other std-only feature in this crate — `connect`, `axum`, `utoipa`, etc. — requires it), so `no-default-features + alloc + opentelemetry` builds (the exact combination `sealwiz-sdk` and `brefwiz-spiffe`'s SDKs use) failed with an unresolved `String` type in `propagation.rs`, since `opentelemetry` itself is not `no_std`-compatible.

Caught by sealwiz#561 and brefwiz-spiffe#246's CI.

## Test plan

- [x] `make ci-lint` / `make ci-format` pass
- [ ] sealwiz-sdk / brefwiz-spiffe CI green once bumped to 6.7.1
