### PR TITLE
feat(tower): client-side TraceContextLayer for automatic W3C trace propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.8.0] — 2026-07-20
+
+### Added
+
+- **`api-bones-tower`: client-side `TraceContextLayer`** (api-bones-tower 4.5.0),
+  behind that crate's new `opentelemetry` feature. A Tower `Layer` / `Service`
+  that injects the active W3C trace context (`traceparent` / `tracestate`) into
+  every **outbound** request's headers. Because `connectrpc` client transports
+  are `tower::Service`s, stacking this layer once on a client transport makes
+  every call through that client propagate trace context automatically — no
+  per-call `inject_current` boilerplate, and a background task's calls link into
+  a trace exactly like a request handler's, as long as the caller runs inside a
+  span. Reads `Context::current()` at dispatch and is a transparent no-op when no
+  span is active. Complements the existing outbound `propagation::inject_current`
+  helper and the server-side context extraction.
+
+The `api-bones` core crate carries no functional change at 6.8.0; the minor bump
+mints the workspace release train that publishes `api-bones-tower` 4.5.0.
+
 ## [6.7.1] — 2026-07-18
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "api-bones"
-version = "6.7.1"
+version = "6.8.0"
 dependencies = [
  "arbitrary",
  "axum",
@@ -190,11 +190,13 @@ dependencies = [
 
 [[package]]
 name = "api-bones-tower"
-version = "4.4.0"
+version = "4.5.0"
 dependencies = [
  "api-bones",
  "http",
  "http-body",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "pin-project",
  "serde_json",
  "tokio",
@@ -314,7 +316,7 @@ checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.0",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -1255,9 +1257,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "ferroid"
@@ -2812,7 +2814,7 @@ checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.0",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -3214,7 +3216,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.0",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -3230,9 +3232,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -3269,7 +3271,7 @@ checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.0",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -3531,9 +3533,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.0"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fac314a64dc9a36e61a9eb4261a5e9bbfbc922b27e518af97bc32b926cf967"
+checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3662,7 +3664,7 @@ checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.0",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -3973,7 +3975,7 @@ checksum = "f153acc4e99a5f2a5aefa09fb078be54e26271b2813f6041200b224c098d8328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.0",
+ "syn 3.0.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ pedantic = { level = "deny", priority = -1 }
 
 [package]
 name = "api-bones"
-version = "6.7.1"
+version = "6.8.0"
 edition = "2024"
 authors = ["Gregoire Salingue"]
 license = "MIT"

--- a/api-bones-tower/Cargo.toml
+++ b/api-bones-tower/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api-bones-tower"
-version = "4.4.0"
+version = "4.5.0"
 edition = "2024"
 authors = ["Gregoire Salingue"]
 license = "MIT"
@@ -26,6 +26,9 @@ rust-version = "1.85"
 uuid = ["api-bones/uuid"]
 ## Enables chrono timestamp support via api-bones/chrono.
 chrono = ["api-bones/chrono"]
+## Enables the client-side `TraceContextLayer` (W3C trace-context injection on
+## outbound requests) via api-bones/opentelemetry.
+opentelemetry = ["api-bones/opentelemetry"]
 
 [dependencies]
 api-bones = { version = "6", path = "..", default-features = false, features = ["std", "serde"] }
@@ -56,6 +59,10 @@ option_if_let_else = "allow"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }
+# For the TraceContextLayer test: install a W3C propagator + an active span,
+# then assert the layer injects `traceparent` on the outbound request.
+opentelemetry = { version = "0.24" }
+opentelemetry_sdk = { version = "0.24", features = ["trace", "rt-tokio"] }
 
 [[example]]
 name = "request_id"

--- a/api-bones-tower/src/lib.rs
+++ b/api-bones-tower/src/lib.rs
@@ -3,20 +3,22 @@
 //! Provides composable Tower [`Layer`](tower::Layer) / [`Service`](tower::Service)
 //! implementations for:
 //!
-//! | Layer                | What it does                                         |
-//! |----------------------|------------------------------------------------------|
-//! | [`RequestIdLayer`]   | Generates / propagates `X-Request-Id` on every req  |
-//! | [`ProblemJsonLayer`] | Maps non-`ApiError` inner-service errors to Problem+JSON |
+//! | Layer                 | What it does                                         |
+//! |-----------------------|------------------------------------------------------|
+//! | [`RequestIdLayer`]    | Generates / propagates `X-Request-Id` on every req  |
+//! | [`ProblemJsonLayer`]  | Maps non-`ApiError` inner-service errors to Problem+JSON |
+//! | `TraceContextLayer`   | Injects W3C `traceparent`/`tracestate` on every outbound request (feature `opentelemetry`) |
 //!
 //! ## Feature flags
 //!
 //! By default this crate enables `std` and `serde` on `api-bones`.
 //! Additional `api-bones` features can be opted into:
 //!
-//! | Feature  | What it enables                              |
-//! |----------|----------------------------------------------|
-//! | `uuid`   | UUID-based request IDs (`api-bones/uuid`)    |
-//! | `chrono` | Chrono timestamp types (`api-bones/chrono`)  |
+//! | Feature         | What it enables                                                   |
+//! |-----------------|-------------------------------------------------------------------|
+//! | `uuid`          | UUID-based request IDs (`api-bones/uuid`)                         |
+//! | `chrono`        | Chrono timestamp types (`api-bones/chrono`)                       |
+//! | `opentelemetry` | Client-side `TraceContextLayer` — outbound W3C trace-context injection |
 //!
 //! # Example
 //!
@@ -277,6 +279,93 @@ fn api_error_to_response(err: ApiError) -> Response<String> {
 }
 
 // ---------------------------------------------------------------------------
+// TraceContextLayer
+// ---------------------------------------------------------------------------
+
+/// Tower [`Layer`] that injects the active OpenTelemetry trace context into
+/// every outbound request's headers.
+///
+/// It emits W3C `traceparent` / `tracestate` so the callee's span links to the
+/// caller's span instead of starting a fresh orphan-root trace.
+///
+/// This is the client-side complement of the server-side context extraction
+/// the inbound middleware performs. Stack it once on any [`tower::Service`]-based
+/// HTTP transport — for example a `connectrpc` client transport, which is a
+/// `tower::Service<http::Request<_>>` — and **every** call made through that
+/// client propagates trace context automatically: no per-call code, no per-SDK
+/// `inject_current` boilerplate. That "inject on every outbound call, for any
+/// reason" property is the whole point — a background poller's calls propagate
+/// exactly like a request handler's, as long as the caller runs inside a span.
+///
+/// Injection reads [`opentelemetry::Context::current`] at dispatch time, so it
+/// carries whatever span is active on the calling task. When no span is active
+/// the propagator emits nothing, so the layer is a transparent no-op on
+/// untraced calls rather than a source of malformed headers.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use api_bones_tower::TraceContextLayer;
+/// use tower::ServiceBuilder;
+///
+/// let _svc = ServiceBuilder::new()
+///     .layer(TraceContextLayer::new())
+///     .service(tower::service_fn(|_req: http::Request<()>| async {
+///         Ok::<_, std::convert::Infallible>(http::Response::new(()))
+///     }));
+/// ```
+#[cfg(feature = "opentelemetry")]
+#[derive(Clone, Debug, Default)]
+pub struct TraceContextLayer;
+
+#[cfg(feature = "opentelemetry")]
+impl TraceContextLayer {
+    /// Create a new `TraceContextLayer`.
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[cfg(feature = "opentelemetry")]
+impl<S> Layer<S> for TraceContextLayer {
+    type Service = TraceContextService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        TraceContextService { inner }
+    }
+}
+
+/// Tower [`Service`] produced by [`TraceContextLayer`].
+#[cfg(feature = "opentelemetry")]
+#[derive(Clone, Debug)]
+pub struct TraceContextService<S> {
+    inner: S,
+}
+
+#[cfg(feature = "opentelemetry")]
+impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for TraceContextService<S>
+where
+    S: Service<Request<ReqBody>, Response = Response<ResBody>>,
+{
+    type Response = Response<ResBody>;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: Request<ReqBody>) -> Self::Future {
+        // Inject the active W3C trace context into the outbound request headers
+        // so the callee's span links to the caller's. A no-op when no span is
+        // active on the current task.
+        api_bones::propagation::inject_current(req.headers_mut());
+        self.inner.call(req)
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -430,5 +519,87 @@ mod tests {
         let resp = fut.await.unwrap();
         assert!(resp.headers().contains_key("x-request-id"));
         assert!(ready.load(Ordering::SeqCst));
+    }
+
+    #[cfg(feature = "opentelemetry")]
+    #[tokio::test]
+    async fn trace_context_layer_injects_traceparent_on_outbound() {
+        use std::sync::{Arc, Mutex};
+
+        use opentelemetry::Context as OtelContext;
+        use opentelemetry::global;
+        use opentelemetry::trace::{TraceContextExt as _, Tracer as _, TracerProvider as _};
+        use opentelemetry_sdk::propagation::TraceContextPropagator;
+        use opentelemetry_sdk::trace::TracerProvider as SdkTracerProvider;
+        use tower::ServiceExt as _;
+
+        global::set_text_map_propagator(TraceContextPropagator::new());
+        let provider = SdkTracerProvider::builder().build();
+        let tracer = provider.tracer("test");
+        let span = tracer.start("caller-span");
+        let _guard = OtelContext::current_with_span(span).attach();
+
+        // Capture the headers the inner (transport) service actually receives.
+        let seen: Arc<Mutex<Option<http::HeaderMap>>> = Arc::new(Mutex::new(None));
+        let seen_inner = Arc::clone(&seen);
+        let inner = tower::service_fn(move |req: Request<()>| {
+            let seen = Arc::clone(&seen_inner);
+            async move {
+                *seen.lock().expect("headers mutex poisoned") = Some(req.headers().clone());
+                Ok::<Response<()>, std::convert::Infallible>(Response::new(()))
+            }
+        });
+
+        let svc = TraceContextLayer::new().layer(inner);
+        let req = Request::builder()
+            .uri("/")
+            .body(())
+            .expect("request builds");
+        svc.oneshot(req).await.expect("service call succeeds");
+
+        let headers = seen
+            .lock()
+            .expect("headers mutex poisoned")
+            .take()
+            .expect("inner service ran");
+        assert!(
+            headers.contains_key("traceparent"),
+            "expected traceparent injected into outbound headers, got: {headers:?}"
+        );
+    }
+
+    #[cfg(feature = "opentelemetry")]
+    #[tokio::test]
+    async fn trace_context_layer_is_noop_without_active_span() {
+        use std::sync::{Arc, Mutex};
+
+        use tower::ServiceExt as _;
+
+        let seen: Arc<Mutex<Option<http::HeaderMap>>> = Arc::new(Mutex::new(None));
+        let seen_inner = Arc::clone(&seen);
+        let inner = tower::service_fn(move |req: Request<()>| {
+            let seen = Arc::clone(&seen_inner);
+            async move {
+                *seen.lock().expect("headers mutex poisoned") = Some(req.headers().clone());
+                Ok::<Response<()>, std::convert::Infallible>(Response::new(()))
+            }
+        });
+
+        let svc = TraceContextLayer::new().layer(inner);
+        let req = Request::builder()
+            .uri("/")
+            .body(())
+            .expect("request builds");
+        svc.oneshot(req).await.expect("service call succeeds");
+
+        let headers = seen
+            .lock()
+            .expect("headers mutex poisoned")
+            .take()
+            .expect("inner service ran");
+        assert!(
+            !headers.contains_key("traceparent"),
+            "expected no traceparent header when no span is active, got: {headers:?}"
+        );
     }
 }


### PR DESCRIPTION
## What

Adds a client-side `TraceContextLayer` to `api-bones-tower` (behind a new `opentelemetry` feature): a Tower `Layer` / `Service` that injects the active OpenTelemetry trace context (W3C `traceparent` / `tracestate`) into **every outbound request's** headers.

## Why

Distributed traces break at every service→service hop that uses a raw `connectrpc` generated client (e.g. `quorumauth-edge → quorumauth-origin`): the callee mints a fresh orphan-root trace because no `traceparent` is sent. connectrpc exposes **no client interceptor** and only a *static* `default_headers` hook, so today each SDK must hand-roll per-call `inject_current` in its `CallOptions` (only `sealwiz-sdk` does). This makes propagation automatic at the transport layer for **any** connectrpc client — the "propagate on every call, for any reason (request or background)" property.

## How

connectrpc client transports are `tower::Service<http::Request<_>>`, so a Tower layer composes cleanly. `TraceContextService::call` invokes the existing `api_bones::propagation::inject_current(req.headers_mut())` on each request, then forwards. It reads `Context::current()` at dispatch, so it carries whatever span is active on the calling task — a request handler's span, or a background task's own root span. Transparent no-op when no span is active (the propagator emits nothing).

Adoption is a one-line wrap per client:
`ServiceClient::new(TraceContextLayer::new().layer(transport), config)`.

## Versions

- `api-bones-tower` 4.4.0 → 4.5.0 (the feature).
- `api-bones` core 6.7.1 → 6.8.0 (version-only; mints the `v6.8.0` release train that publishes tower 4.5.0).

## Tests

- `traceparent` injected on the outbound request when a span is active.
- no-op (no `traceparent`) when no span is active.
