### PR TITLE
chore: align opentelemetry 0.24→0.32 to fix cross-boundary trace propagation (6.9.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.9.0] — 2026-07-20
+
+### Changed
+
+- **Aligned `opentelemetry` / `opentelemetry_sdk` from `0.24` to `0.32`** to match
+  `otel-bootstrap` (the platform's tracing bootstrap). This is a dependency
+  alignment, not a public-API change — `inject_current(&mut HeaderMap)` and the
+  rest of the `opentelemetry`-feature surface are unchanged.
+
+  **Why it matters:** `opentelemetry` 0.x minors are semver-incompatible, so a
+  graph carrying both `0.24` (old api-bones) and `0.32` (otel-bootstrap)
+  maintained **two separate task-local `Context::current()` stacks**.
+  `otel-bootstrap`'s port/axum spans set the active context in the `0.32` stack,
+  while api-bones' `inject_current` read the `0.24` stack — which was empty — so
+  **no `traceparent` was injected** on any outbound call whose parent span was
+  minted by otel-bootstrap. Client spans (KMS/gRPC ports, connectrpc SDK calls)
+  silently produced disconnected root spans instead of linked children. Unifying
+  on `0.32` makes both share one context stack, so trace context propagates
+  end-to-end across the api-bones ↔ otel-bootstrap boundary.
+
 ## [6.8.0] — 2026-07-20
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "api-bones"
-version = "6.8.0"
+version = "6.9.0"
 dependencies = [
  "arbitrary",
  "axum",
@@ -113,7 +113,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
- "thiserror 2.0.19",
+ "thiserror",
  "tokio",
  "tracing",
  "utoipa",
@@ -181,7 +181,7 @@ dependencies = [
  "serde",
  "serde_json",
  "testcontainers",
- "thiserror 2.0.19",
+ "thiserror",
  "tokio",
  "tower",
  "uuid",
@@ -274,7 +274,7 @@ dependencies = [
  "serde_json",
  "serde_nanos",
  "serde_repr",
- "thiserror 2.0.19",
+ "thiserror",
  "time",
  "tokio",
  "tokio-rustls",
@@ -519,7 +519,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_urlencoded",
- "thiserror 2.0.19",
+ "thiserror",
  "time",
  "tokio",
  "tokio-stream",
@@ -593,7 +593,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smol_str",
- "thiserror 2.0.19",
+ "thiserror",
 ]
 
 [[package]]
@@ -606,7 +606,7 @@ dependencies = [
  "bytes",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror",
 ]
 
 [[package]]
@@ -827,7 +827,7 @@ dependencies = [
  "rustls-pki-types",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror",
  "tokio",
  "tokio-rustls",
  "tokio-util",
@@ -1228,7 +1228,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror",
  "typetag",
  "uuid",
 ]
@@ -1464,12 +1464,6 @@ dependencies = [
  "rand_core 0.10.1",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "glob"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
@@ -1945,7 +1939,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.19",
+ "thiserror",
  "walkdir",
  "windows-link",
 ]
@@ -2273,35 +2267,32 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opentelemetry"
-version = "0.24.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c365a63eec4f55b7efeceb724f1336f26a9cf3427b70e59e2cd2a5b947fba96"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
  "futures-core",
  "futures-sink",
  "js-sys",
- "once_cell",
  "pin-project-lite",
- "thiserror 1.0.69",
+ "thiserror",
+ "tracing",
 ]
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.24.1"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692eac490ec80f24a17828d49b40b60f5aeaccdfe6a503f939713afd22bc28df"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
 dependencies = [
- "async-trait",
  "futures-channel",
  "futures-executor",
  "futures-util",
- "glob",
- "once_cell",
  "opentelemetry",
  "percent-encoding",
- "rand 0.8.7",
- "serde_json",
- "thiserror 1.0.69",
+ "portable-atomic",
+ "rand 0.9.5",
+ "thiserror",
  "tokio",
  "tokio-stream",
 ]
@@ -2525,7 +2516,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn 2.0.119",
- "thiserror 2.0.19",
+ "thiserror",
  "typify",
  "unicode-ident",
 ]
@@ -2630,7 +2621,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.19",
+ "thiserror",
  "tokio",
  "tracing",
  "web-time",
@@ -2653,7 +2644,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.19",
+ "thiserror",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2906,7 +2897,7 @@ version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71ea98a177596a4579881992bd2bd4af27772fc95d0e5f5668a8f9535eca6380"
 dependencies = [
- "thiserror 2.0.19",
+ "thiserror",
 ]
 
 [[package]]
@@ -2935,7 +2926,7 @@ dependencies = [
  "http",
  "mime",
  "rand 0.10.2",
- "thiserror 2.0.19",
+ "thiserror",
 ]
 
 [[package]]
@@ -3620,7 +3611,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.19",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -3629,31 +3620,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.19",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -3669,9 +3640,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.53"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
 dependencies = [
  "deranged",
  "num-conv",
@@ -3689,9 +3660,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4004,7 +3975,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn 2.0.119",
- "thiserror 2.0.19",
+ "thiserror",
  "unicode-ident",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ pedantic = { level = "deny", priority = -1 }
 
 [package]
 name = "api-bones"
-version = "6.8.0"
+version = "6.9.0"
 edition = "2024"
 authors = ["Gregoire Salingue"]
 license = "MIT"
@@ -97,7 +97,7 @@ connectrpc  = { version = "0.7", features = ["client", "client-tls"], optional =
 buffa-types = { version = "0.7", features = ["json"], optional = true }
 rustls-native-certs = { version = "0.8", optional = true }
 tracing     = { version = "0.1", optional = true }
-opentelemetry = { version = "0.24", optional = true }
+opentelemetry = { version = "0.32", optional = true }
 
 [lints.rust]
 # Allow cfg(coverage) set by cargo-llvm-cov
@@ -126,7 +126,7 @@ option_if_let_else = "allow"         # nursery: map_or_else is less readable in 
 [dev-dependencies]
 mockito = "1.7.2"
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "net"] }
-opentelemetry_sdk = { version = "0.24", features = ["trace", "rt-tokio"] }
+opentelemetry_sdk = { version = "0.32", features = ["trace", "rt-tokio"] }
 
 [[example]]
 name = "query_builder"

--- a/api-bones-tower/Cargo.toml
+++ b/api-bones-tower/Cargo.toml
@@ -61,8 +61,8 @@ option_if_let_else = "allow"
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }
 # For the TraceContextLayer test: install a W3C propagator + an active span,
 # then assert the layer injects `traceparent` on the outbound request.
-opentelemetry = { version = "0.24" }
-opentelemetry_sdk = { version = "0.24", features = ["trace", "rt-tokio"] }
+opentelemetry = { version = "0.32" }
+opentelemetry_sdk = { version = "0.32", features = ["trace", "rt-tokio"] }
 
 [[example]]
 name = "request_id"

--- a/api-bones-tower/src/lib.rs
+++ b/api-bones-tower/src/lib.rs
@@ -530,7 +530,7 @@ mod tests {
         use opentelemetry::global;
         use opentelemetry::trace::{TraceContextExt as _, Tracer as _, TracerProvider as _};
         use opentelemetry_sdk::propagation::TraceContextPropagator;
-        use opentelemetry_sdk::trace::TracerProvider as SdkTracerProvider;
+        use opentelemetry_sdk::trace::SdkTracerProvider;
         use tower::ServiceExt as _;
 
         global::set_text_map_propagator(TraceContextPropagator::new());

--- a/src/propagation.rs
+++ b/src/propagation.rs
@@ -80,7 +80,7 @@ mod tests {
     fn traceparent_injected_with_propagator_and_active_span() {
         use opentelemetry::trace::{TraceContextExt, Tracer, TracerProvider};
         use opentelemetry_sdk::propagation::TraceContextPropagator;
-        use opentelemetry_sdk::trace::TracerProvider as SdkTracerProvider;
+        use opentelemetry_sdk::trace::SdkTracerProvider;
 
         global::set_text_map_propagator(TraceContextPropagator::new());
         let provider = SdkTracerProvider::builder().build();


### PR DESCRIPTION
## What

Align api-bones' `opentelemetry` / `opentelemetry_sdk` dependency from **0.24 → 0.32**, matching `otel-bootstrap`. Bumps api-bones `6.8.0 → 6.9.0`.

## Why — this is the root cause of the missing Tempo links

Distributed traces were breaking silently across the mesh: `quorumauth-origin → sealwiz` (and every otel-bootstrap-span → api-bones-inject hop) produced **disconnected root spans** instead of linked children.

Root cause: **two incompatible `opentelemetry` versions in the same binary.**

- `otel-bootstrap` (port/axum span instrumentation) is on `opentelemetry 0.32`.
- api-bones (`inject_current`, used by `sealwiz-sdk` `call_options` and the new `TraceContextLayer`) was on `opentelemetry 0.24`.

`opentelemetry` 0.x minors are semver-incompatible, so `0.24` and `0.32` keep **separate task-local `Context::current()` stacks**. otel-bootstrap's `Instrumented` port wrapper / `axum_layer` set the active span in the `0.32` stack; api-bones' `inject_current` read the `0.24` stack → **empty** → no `traceparent` written to outbound headers. Every hop where a span was minted by otel-bootstrap and injection was done by api-bones broke, invisibly.

Confirmed in `quorumauth 0.37.1`'s `Cargo.lock`: it resolved **both** `opentelemetry 0.24.0` and `0.32.0`.

Unifying on `0.32` makes both share one context stack → `traceparent` propagates end-to-end.

## Changes

- `Cargo.toml` (core): `opentelemetry` `0.24 → 0.32` (optional, behind `opentelemetry` feature); dev-dep `opentelemetry_sdk` `0.24 → 0.32`.
- `api-bones-tower/Cargo.toml`: dev-deps `opentelemetry` / `opentelemetry_sdk` `0.24 → 0.32`.
- Test-only import fix for the 0.32 rename `opentelemetry_sdk::trace::TracerProvider` → `SdkTracerProvider` (2 test modules). **No production code changed** — the `inject_current` propagation logic is byte-identical; the public API surface is unchanged.
- `Cargo.lock` regenerated → single `opentelemetry 0.32.0`.

## Semver

Minor bump. `opentelemetry` is **not** in api-bones' public API (no `pub use`, `inject_current(&mut HeaderMap)` takes no otel types) — this is a transitive-dependency alignment, not a breaking API change.

## Follow-up (same campaign)

- A **blocking** ci-workflows canonical-check that fails any workspace lockfile resolving >1 `opentelemetry` version, so this split cannot silently recur.
- Re-propagate through `sealwiz-sdk` → `service-kit` → consumers, redeploy, verify `origin → sealwiz` links in Tempo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
