### PR TITLE
feat(otel): capture active context for delayed callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`api-bones-otel` 0.1.1:** `captureTraceContext()` snapshots active
+  OpenTelemetry context for delayed callbacks and stream events, allowing
+  explicit injection after ambient async context changes.
+
 ## [6.9.0] — 2026-07-20
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,7 +316,7 @@ checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -690,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.2"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -712,14 +712,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1609,9 +1609,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1631,9 +1631,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-named-pipe"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
+checksum = "fab3637d6b04a8037af8a266fdf6cf92ea957e8c53981a2bf6136572531025bf"
 dependencies = [
  "hex",
  "hyper",
@@ -1641,7 +1641,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tower-service",
- "winapi",
 ]
 
 [[package]]
@@ -2005,9 +2004,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2805,7 +2804,7 @@ checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3207,7 +3206,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3262,7 +3261,7 @@ checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3524,9 +3523,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3635,7 +3634,7 @@ checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3695,9 +3694,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.53.0"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d988bcd52dbe076d3d46903332f58c912b87a2c49b1428419a5845154762ffee"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -3733,9 +3732,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -3744,13 +3743,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -3946,7 +3946,7 @@ checksum = "f153acc4e99a5f2a5aefa09fb078be54e26271b2813f6041200b224c098d8328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4567,18 +4567,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Makefile
+++ b/Makefile
@@ -149,4 +149,4 @@ pre-commit: ci-format ci-lint ci-test ci-changelog ## Run all pre-commit checks 
 
 .PHONY: ci-changelog
 ci-changelog: ## CI: verify CHANGELOG.md has entry for current package version (ADR-0021)
-	@bash <(curl -fsSL https://raw.githubusercontent.com/brefwiz/shared-ci-workflows/main/scripts/check-release-changelog.sh)
+	@curl -fsSL https://raw.githubusercontent.com/brefwiz/shared-ci-workflows/main/scripts/check-release-changelog.sh | bash

--- a/api-bones-otel/package-lock.json
+++ b/api-bones-otel/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brefwiz/api-bones-otel",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brefwiz/api-bones-otel",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "devDependencies": {
         "@connectrpc/connect": "^2.0.0",

--- a/api-bones-otel/package.json
+++ b/api-bones-otel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brefwiz/api-bones-otel",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "OpenTelemetry W3C trace-context propagation interceptors for Brefwiz Connect-ES SDKs",
   "author": "Brefwiz Team",
   "license": "MIT",

--- a/api-bones-otel/src/index.test.ts
+++ b/api-bones-otel/src/index.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, beforeEach } from "vitest";
-import { context, trace, propagation, SpanContext, TraceFlags } from "@opentelemetry/api";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { context, trace, propagation, ROOT_CONTEXT, SpanContext, TraceFlags } from "@opentelemetry/api";
 import { W3CTraceContextPropagator } from "@opentelemetry/core";
 import type { UnaryRequest } from "@connectrpc/connect";
-import { addTraceContextInterceptor, injectTraceContext } from "./index";
+import { addTraceContextInterceptor, captureTraceContext, injectTraceContext } from "./index";
 
 // Register a W3C propagator for testing
 const propagator = new W3CTraceContextPropagator();
@@ -89,6 +89,25 @@ describe("injectTraceContext", () => {
 
     expect(carrier.traceparent).toBeDefined();
     expect(carrier.traceparent).toMatch(/^00-[a-f0-9]{32}-[a-f0-9]{16}-[01][0-9a-f]$/);
+  });
+
+  it("injects a captured context after ambient context changes", () => {
+    const activeCtx = trace.setSpanContext(context.active(), createMockSpanContext());
+    const active = vi.spyOn(context, "active").mockReturnValue(activeCtx);
+    const delayedCallbackSource = new EventTarget();
+    const captured = captureTraceContext();
+    const carrier: Record<string, string> = {};
+
+    active.mockReturnValue(ROOT_CONTEXT);
+    delayedCallbackSource.addEventListener("end", () => {
+      injectTraceContext(carrier, captured);
+    });
+    delayedCallbackSource.dispatchEvent(new Event("end"));
+
+    expect(carrier.traceparent).toBe(
+      "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+    );
+    active.mockRestore();
   });
 
   it("handles errors gracefully", () => {

--- a/api-bones-otel/src/index.ts
+++ b/api-bones-otel/src/index.ts
@@ -9,6 +9,18 @@ import type { Interceptor } from "@connectrpc/connect";
 // ---------------------------------------------------------------------------
 
 /**
+ * Capture the currently active OpenTelemetry context for later use.
+ *
+ * Capture synchronously while the request span is active, then pass the
+ * returned context to {@link injectTraceContext} from delayed callbacks whose
+ * async resource may have been created before the span. This avoids relying on
+ * ambient context after crossing EventEmitter, stream, or callback boundaries.
+ */
+export function captureTraceContext(): Context {
+  return context.active();
+}
+
+/**
  * Inject the active OpenTelemetry trace context as W3C trace headers
  * into a carrier (plain object, Headers, or Map-like).
  *
@@ -33,7 +45,7 @@ export function injectTraceContext(
   ctx?: Context,
 ): void {
   try {
-    const targetContext = ctx ?? context.active();
+    const targetContext = ctx ?? captureTraceContext();
     propagation.inject(targetContext, carrier, {
       set: (c: Record<string, string> | Headers | Map<string, string>, key: string, value: string) => {
         if (c instanceof Headers) {


### PR DESCRIPTION
Add `captureTraceContext()` to `@brefwiz/api-bones-otel` so request code can snapshot active OpenTelemetry context before crossing delayed callback, stream, or EventEmitter boundaries, then pass it to shared `injectTraceContext()`.

Includes regression coverage for ambient-context loss, bumps package lane to 0.1.1, and makes changelog gate portable under Make's POSIX shell.
