### PR TITLE
feat(connect): add @brefwiz/api-bones-connect with web and node transport profiles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,12 +3,16 @@ name: Release
 # Rust crates release on `v*` tags (e.g. v4.3.0).
 # The `@brefwiz/api-bones-axios` npm package releases on `axios-v*` tags
 # (e.g. axios-v0.1.1) so its cadence is independent of the Rust workspace.
+# `@brefwiz/api-bones-connect` releases on `connect-v*` tags, same pattern.
+# Note the Rust crate `api-bones-connect` releases on `v*` with the workspace —
+# same name, different artifact and different cadence, hence the tag prefix.
 on:
   push:
     tags:
       - 'v*'
       - 'axios-v*'
       - 'otel-v*'
+      - 'connect-v*'
 
 jobs:
   release-rust:
@@ -62,6 +66,25 @@ jobs:
             exit 1
           fi
 
+  validate-connect-tag:
+    # Guard against publishing a version that doesn't match the tag.
+    if: startsWith(github.ref, 'refs/tags/connect-v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+      - name: Verify connect-v<version> matches package.json
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/connect-v}"
+          PKG_VERSION="$(node -p "require('./api-bones-connect-ts/package.json').version")"
+          echo "Tag version:     ${TAG_VERSION}"
+          echo "Package version: ${PKG_VERSION}"
+          if [ "${TAG_VERSION}" != "${PKG_VERSION}" ]; then
+            echo "::error::tag connect-v${TAG_VERSION} does not match api-bones-connect-ts/package.json version ${PKG_VERSION}"
+            exit 1
+          fi
+
   release-npm:
     needs: [validate-axios-tag]
     if: startsWith(github.ref, 'refs/tags/axios-v')
@@ -78,6 +101,16 @@ jobs:
     uses: brefwiz/shared-ci-workflows/.github/workflows/release-npm.yml@main
     with:
       packages: "api-bones-otel"
+    permissions:
+      contents: read
+      packages: write
+
+  release-npm-connect:
+    needs: validate-connect-tag
+    if: startsWith(github.ref, 'refs/tags/connect-v')
+    uses: brefwiz/shared-ci-workflows/.github/workflows/release-npm.yml@main
+    with:
+      packages: "api-bones-connect-ts"
     permissions:
       contents: read
       packages: write

--- a/Makefile
+++ b/Makefile
@@ -135,14 +135,29 @@ spec-check: ## L1 ADR-0086: SPEC.md exists and wire_surface is valid
 # ─── TypeScript packages ────────────────────────────────────────────────────
 
 .PHONY: ts-build ts-test ts-lint
+# Every TypeScript package in the repo. Enumerated once and looped over rather
+# than named per target: these were hardcoded to api-bones-otel alone, so
+# api-bones-axios shipped without its build or tests ever running in CI despite
+# having both scripts. A list makes adding a package a one-line change and makes
+# an omission visible.
+TS_PACKAGES := api-bones-otel api-bones-axios api-bones-connect-ts
+
 ts-build: ## Build TypeScript packages
-	cd api-bones-otel && npm install && npm run build
+	@set -e; for pkg in $(TS_PACKAGES); do \
+		echo "==> build $$pkg"; \
+		( cd $$pkg && npm install --no-audit --no-fund && npm run build ); \
+	done
 
 ts-test: ## Test TypeScript packages
-	cd api-bones-otel && npm install && npm run test
+	@set -e; for pkg in $(TS_PACKAGES); do \
+		echo "==> test $$pkg"; \
+		( cd $$pkg && npm install --no-audit --no-fund && npm run test ); \
+	done
 
 ts-lint: ## Lint TypeScript packages (format check + biome)
-	cd api-bones-otel && npm install
+	@set -e; for pkg in $(TS_PACKAGES); do \
+		( cd $$pkg && npm install --no-audit --no-fund ); \
+	done
 
 .PHONY: pre-commit
 pre-commit: ci-format ci-lint ci-test ci-changelog ## Run all pre-commit checks (ADR-0021)

--- a/api-bones-connect-ts/package-lock.json
+++ b/api-bones-connect-ts/package-lock.json
@@ -1,0 +1,1677 @@
+{
+  "name": "@brefwiz/api-bones-connect",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@brefwiz/api-bones-connect",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@bufbuild/protobuf": "^2.0.0",
+        "@connectrpc/connect": "^2.0.0",
+        "@connectrpc/connect-node": "^2.0.0",
+        "@connectrpc/connect-web": "^2.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.0"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.0.0",
+        "@connectrpc/connect": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@connectrpc/connect-node": {
+          "optional": true
+        },
+        "@connectrpc/connect-web": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.13.0.tgz",
+      "integrity": "sha512-acq7c49vxfm1ggJ95P70TX7ABDM0vxr1SYD3BB0o0jnBLB4OAqeHyKuN+cD3w80gXEDQ2zxHpR6CUeA+O/aU9g==",
+      "dev": true,
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@connectrpc/connect": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.2.tgz",
+      "integrity": "sha512-MXkBijtcX09R10Eb6sFeIetc6w6746eio6xtfuyVOH7oQAacT1X0GzMIQFux6Qy8cq3W/T5qX5Bei8YbFtmRGA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.7.0"
+      }
+    },
+    "node_modules/@connectrpc/connect-node": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-node/-/connect-node-2.1.2.tgz",
+      "integrity": "sha512-+i/aAOpsI8sIx1mbYp6d99zvxaUSF6t/jP9Ux9maAmjsZPgmIQ3JuIeYi0zJIP9zlCnBlJjkpPosshCgdRuThQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.7.0",
+        "@connectrpc/connect": "2.1.2"
+      }
+    },
+    "node_modules/@connectrpc/connect-web": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-web/-/connect-web-2.1.2.tgz",
+      "integrity": "sha512-1tfaK85MU+gJjwwmL31d2rzdf0XCYX99chZf63uG89SGBUd4XuZ4ZzhGo2u79TPXOE6nLIZQ2okrpyey42PYdg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.7.0",
+        "@connectrpc/connect": "2.1.2"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+      "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+      "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+      "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+      "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+      "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+      "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+      "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+      "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+      "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+      "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+      "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+      "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+      "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+      "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+      "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+      "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+      "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+      "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+      "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+      "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+      "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+      "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+      "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+      "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.4",
+        "@rollup/rollup-android-arm64": "4.62.4",
+        "@rollup/rollup-darwin-arm64": "4.62.4",
+        "@rollup/rollup-darwin-x64": "4.62.4",
+        "@rollup/rollup-freebsd-arm64": "4.62.4",
+        "@rollup/rollup-freebsd-x64": "4.62.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+        "@rollup/rollup-linux-arm64-musl": "4.62.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+        "@rollup/rollup-linux-loong64-musl": "4.62.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-musl": "4.62.4",
+        "@rollup/rollup-openbsd-x64": "4.62.4",
+        "@rollup/rollup-openharmony-arm64": "4.62.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+        "@rollup/rollup-win32-x64-gnu": "4.62.4",
+        "@rollup/rollup-win32-x64-msvc": "4.62.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/api-bones-connect-ts/package.json
+++ b/api-bones-connect-ts/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@brefwiz/api-bones-connect",
+  "version": "0.1.0",
+  "description": "Canonical Connect transport profiles for Brefwiz SDKs — shared policy core with browser and Node adapters",
+  "author": "Brefwiz Team",
+  "license": "MIT",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./web": {
+      "import": "./dist/web.js",
+      "require": "./dist/web.js",
+      "types": "./dist/web.d.ts"
+    },
+    "./node": {
+      "import": "./dist/node.js",
+      "require": "./dist/node.js",
+      "types": "./dist/node.d.ts"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run"
+  },
+  "peerDependencies": {
+    "@bufbuild/protobuf": "^2.0.0",
+    "@connectrpc/connect": "^2.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@connectrpc/connect-web": { "optional": true },
+    "@connectrpc/connect-node": { "optional": true }
+  },
+  "devDependencies": {
+    "@bufbuild/protobuf": "^2.0.0",
+    "@connectrpc/connect": "^2.0.0",
+    "@connectrpc/connect-node": "^2.0.0",
+    "@connectrpc/connect-web": "^2.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
+  }
+}

--- a/api-bones-connect-ts/src/backoff.ts
+++ b/api-bones-connect-ts/src/backoff.ts
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+//
+// Retry backoff maths, moved verbatim from core-ui's
+// src/data/subscriptions/backoff.ts. Pure arithmetic with no runtime
+// dependencies, so the browser transport, the Node transport, and core-ui's
+// subscription hooks can all share one copy — a Node service transport must not
+// import from a UI package to get its retry schedule.
+//
+// Behaviour is deliberately unchanged: same option names, same defaults
+// (500ms initial, 30s cap, x2), same floor-and-full-jitter delay, same
+// injectable `random` for deterministic tests. Retiming retries while relocating
+// them would be an invisible behaviour change to every existing consumer.
+
+export interface BackoffOptions {
+  initialDelayMs?: number;
+  maxDelayMs?: number;
+  multiplier?: number;
+}
+
+export interface BackoffConfig {
+  initialDelayMs: number;
+  maxDelayMs: number;
+  multiplier: number;
+}
+
+export const DEFAULT_BACKOFF: BackoffConfig = {
+  initialDelayMs: 500,
+  maxDelayMs: 30000,
+  multiplier: 2,
+};
+
+export function resolveBackoff(opts?: BackoffOptions): BackoffConfig {
+  return {
+    initialDelayMs: opts?.initialDelayMs ?? DEFAULT_BACKOFF.initialDelayMs,
+    maxDelayMs: opts?.maxDelayMs ?? DEFAULT_BACKOFF.maxDelayMs,
+    multiplier: opts?.multiplier ?? DEFAULT_BACKOFF.multiplier,
+  };
+}
+
+export function computeBackoffDelay(
+  attempt: number,
+  config: BackoffConfig,
+  random: () => number = Math.random,
+): number {
+  const safeAttempt = Math.max(0, Math.floor(attempt));
+  const exp = config.initialDelayMs * Math.pow(config.multiplier, safeAttempt);
+  const capped = Math.min(exp, config.maxDelayMs);
+  return Math.floor(random() * capped);
+}

--- a/api-bones-connect-ts/src/index.test.ts
+++ b/api-bones-connect-ts/src/index.test.ts
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: MIT
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_BACKOFF,
+  computeBackoffDelay,
+  resolveBackoff,
+} from "./backoff";
+import {
+  MAX_CONNECT_GET_URL_BYTES,
+  eligibleBrowserReadPolicy,
+  indexGeneratedPolicy,
+} from "./policy";
+import { configureNodeConnectTransport } from "./node";
+
+const method = (over: Record<string, unknown> = {}) => ({
+  rpc: "/svc.v1.S/Get",
+  procedure: "unary",
+  idempotency: "NO_SIDE_EFFECTS",
+  browserCache: { scope: "PRIVATE", maxAgeSeconds: 60 },
+  sensitivity: "NON_SENSITIVE",
+  maxEncodedUrlBytes: 1024,
+  ...over,
+});
+
+describe("backoff", () => {
+  // Pinned by value, not shape. These numbers moved from core-ui and are
+  // consumed by its subscription hooks; changing them while relocating the
+  // module would silently retime every reconnect.
+  it("keeps the defaults it was moved with", () => {
+    expect(DEFAULT_BACKOFF).toEqual({
+      initialDelayMs: 500,
+      maxDelayMs: 30000,
+      multiplier: 2,
+    });
+  });
+
+  it("grows exponentially, caps, and floors with injected randomness", () => {
+    const config = resolveBackoff();
+    expect(computeBackoffDelay(0, config, () => 1)).toBe(500);
+    expect(computeBackoffDelay(1, config, () => 1)).toBe(1000);
+    // capped, not 500 * 2^10
+    expect(computeBackoffDelay(10, config, () => 1)).toBe(30000);
+  });
+
+  it("treats negative attempts as zero rather than inverting the delay", () => {
+    const config = resolveBackoff();
+    expect(computeBackoffDelay(-5, config, () => 1)).toBe(500);
+  });
+});
+
+describe("policy", () => {
+  it("indexes a well-formed document", () => {
+    const index = indexGeneratedPolicy({ schemaVersion: 1, methods: [method()] });
+    expect(index.size).toBe(1);
+  });
+
+  // Fail-closed is the security property: a partially-parseable policy must
+  // grant nothing, not the subset that happened to parse.
+  it("fails closed to an empty index on a duplicate rpc", () => {
+    const index = indexGeneratedPolicy({
+      schemaVersion: 1,
+      methods: [method(), method()],
+    });
+    expect(index.size).toBe(0);
+  });
+
+  it("fails closed on a malformed entry", () => {
+    const index = indexGeneratedPolicy({
+      schemaVersion: 1,
+      methods: [method(), method({ browserCache: { scope: "BOGUS", maxAgeSeconds: 1 } })],
+    });
+    expect(index.size).toBe(0);
+  });
+
+  it("rejects a url budget above the protocol ceiling", () => {
+    expect(eligibleBrowserReadPolicy(method({ maxEncodedUrlBytes: MAX_CONNECT_GET_URL_BYTES + 1 })))
+      .toBeNull();
+  });
+
+  it("refuses browser reads for sensitive or side-effecting methods", () => {
+    expect(eligibleBrowserReadPolicy(method({ sensitivity: "UNSPECIFIED" }))).toBeNull();
+    expect(eligibleBrowserReadPolicy(method({ idempotency: "IDEMPOTENT" }))).toBeNull();
+    expect(eligibleBrowserReadPolicy(method({ browserCache: { scope: "NO_STORE", maxAgeSeconds: 0 } })))
+      .toBeNull();
+  });
+});
+
+describe("node transport", () => {
+  // A Node process cannot issue a browser request, so accepting "webapp" would
+  // accept a composition-root mistake silently.
+  it("rejects the webapp profile instead of downgrading it", () => {
+    expect(() =>
+      configureNodeConnectTransport({ baseUrl: "https://svc", profile: "webapp" }),
+    ).toThrow(/must be "service"/);
+  });
+
+  it("builds a transport for the service profile", () => {
+    const transport = configureNodeConnectTransport({
+      baseUrl: "https://svc",
+      profile: "service",
+    });
+    expect(transport).toHaveProperty("unary");
+    expect(transport).toHaveProperty("stream");
+  });
+
+  it("accepts a well-formed policy", () => {
+    expect(() =>
+      configureNodeConnectTransport({
+        baseUrl: "https://svc",
+        profile: "service",
+        policy: { schemaVersion: 1, methods: [method()] },
+      }),
+    ).not.toThrow();
+  });
+
+  // Services validate the same artifact webapps do, so a drifted policy is
+  // caught wherever it is first composed rather than only in a browser.
+  it("rejects a policy that fails closed while claiming methods", () => {
+    expect(() =>
+      configureNodeConnectTransport({
+        baseUrl: "https://svc",
+        profile: "service",
+        policy: { schemaVersion: 1, methods: [method(), method()] },
+      }),
+    ).toThrow(/malformed or has duplicate RPC entries/);
+  });
+});

--- a/api-bones-connect-ts/src/index.ts
+++ b/api-bones-connect-ts/src/index.ts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+//
+// Runtime-agnostic entry point: the policy contract and retry maths shared by
+// both adapters. Importing this pulls in neither `@connectrpc/connect-web` nor
+// `@connectrpc/connect-node`, so a consumer that only needs the types or the
+// policy helpers never acquires a runtime it cannot use.
+//
+// Transports live behind explicit subpaths, so the runtime is a deliberate
+// choice at the composition root rather than something resolved by accident:
+//
+//   import { configureConnectTransport }     from "@brefwiz/api-bones-connect/web";
+//   import { configureNodeConnectTransport } from "@brefwiz/api-bones-connect/node";
+
+export {
+  DEFAULT_BACKOFF,
+  computeBackoffDelay,
+  resolveBackoff,
+  type BackoffConfig,
+  type BackoffOptions,
+} from "./backoff";
+
+export {
+  MAX_CONNECT_GET_URL_BYTES,
+  MAX_PRIVATE_CACHE_TTL_SECONDS,
+  eligibleBrowserReadPolicy,
+  indexGeneratedPolicy,
+  parseMethodPolicy,
+  type GeneratedBrowserCachePolicy,
+  type GeneratedMethodPolicy,
+  type GeneratedMethodPolicyDocument,
+  type SdkTransportProfile,
+} from "./policy";

--- a/api-bones-connect-ts/src/node.ts
+++ b/api-bones-connect-ts/src/node.ts
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: MIT
+//
+// Canonical Node/service Connect transport.
+//
+// This is the half that did not exist. The browser adapter has always been able
+// to name its profile; a CLI, a mesh service, or a test harness had no
+// canonical helper at all, so every one of them constructed a transport by hand
+// — which is what `connect-read-profile` flags, and what nobody could fix
+// because there was nothing to migrate to.
+//
+// A service transport is POST-only BY CONSTRUCTION, not by policy. The profile
+// enum's only behavioural effect is browser GET eligibility, and a Node process
+// issues no browser requests: there is no cache to populate, no URL length
+// limit to respect, and no cross-origin credential story. So this adapter
+// accepts the same policy document as the browser one and uses it for nothing
+// but validation — see `configureNodeConnectTransport` for why it takes it at
+// all rather than pretending the two profiles are unrelated.
+
+import type { Interceptor, Transport } from "@connectrpc/connect";
+import { Code, ConnectError } from "@connectrpc/connect";
+import {
+  compressionBrotli,
+  compressionGzip,
+  createConnectTransport,
+} from "@connectrpc/connect-node";
+
+import type { BackoffOptions } from "./backoff";
+import { computeBackoffDelay, resolveBackoff } from "./backoff";
+import { indexGeneratedPolicy, type SdkTransportProfile } from "./policy";
+
+const RETRYABLE_CODES = new Set([Code.Unavailable, Code.Aborted, Code.ResourceExhausted]);
+const MAX_RETRIES = 3;
+
+export interface NodeConnectTransportOptions {
+  baseUrl: string;
+  /**
+   * Accepted for symmetry with the browser adapter and validated, but a Node
+   * transport is always the service profile in behaviour. Passing "webapp"
+   * here is a composition-root mistake — a Node process cannot make a browser
+   * request — so it is rejected rather than silently downgraded.
+   */
+  profile: SdkTransportProfile;
+  /**
+   * The generated policy document. Not used to select a verb here (a service
+   * transport has no GET path), but parsed so a malformed or drifted artifact
+   * fails at composition time in services too, rather than only in webapps.
+   * That keeps one artifact honest across both runtimes instead of leaving
+   * services free to ship a policy nothing ever reads.
+   */
+  policy?: unknown;
+  /** Bearer token provider for service-to-service calls. */
+  getToken?: () => string | null | undefined;
+  /** Called when the server returns Unauthenticated. */
+  onUnauthorized?: () => void;
+  /** Binary protobuf instead of JSON. Default: false. */
+  useBinaryFormat?: boolean;
+  /** Retry options for transient unary failures. */
+  retry?: BackoffOptions;
+  /** Product interceptors, composed ahead of the core ones. */
+  interceptors?: readonly Interceptor[];
+  /** HTTP version. Default "2" — services talk h2 to the mesh. */
+  httpVersion?: "1.1" | "2";
+}
+
+function makeAuthInterceptor(getToken: () => string | null | undefined): Interceptor {
+  return (next) => (req) => {
+    const token = getToken();
+    if (token) {
+      req.header.set("Authorization", `Bearer ${token}`);
+    }
+    return next(req);
+  };
+}
+
+function makeUnauthInterceptor(onUnauthorized: () => void): Interceptor {
+  return (next) => async (req) => {
+    try {
+      return await next(req);
+    } catch (err) {
+      if (err instanceof ConnectError && err.code === Code.Unauthenticated) {
+        onUnauthorized();
+      }
+      throw err;
+    }
+  };
+}
+
+function makeRetryInterceptor(retryOpts?: BackoffOptions): Interceptor {
+  const backoff = resolveBackoff(retryOpts);
+  return (next) => async (req) => {
+    // Only retry unary requests — streams must handle reconnect separately.
+    if (req.stream) return next(req);
+
+    let attempt = 0;
+    for (;;) {
+      try {
+        return await next(req);
+      } catch (err) {
+        if (err instanceof ConnectError && RETRYABLE_CODES.has(err.code) && attempt < MAX_RETRIES) {
+          const delay = computeBackoffDelay(attempt, backoff);
+          await new Promise<void>((resolve) => setTimeout(resolve, delay));
+          attempt++;
+          continue;
+        }
+        throw err;
+      }
+    }
+  };
+}
+
+/**
+ * Build the canonical Connect transport for a Node service, CLI, or harness.
+ *
+ * Deliberately carries no browser machinery: no CSRF meta-tag read, no
+ * `credentials: "include"`, no GET transport. Those are browser-only concerns,
+ * and importing them into a service is how a CLI ends up depending on `document`.
+ *
+ * @example
+ * ```ts
+ * import { configureNodeConnectTransport } from "@brefwiz/api-bones-connect/node";
+ * import policy from "./generated/connect-method-policy.json";
+ *
+ * const transport = configureNodeConnectTransport({
+ *   baseUrl: process.env.SERVICE_URL!,
+ *   profile: "service",
+ *   policy,
+ * });
+ * ```
+ */
+export function configureNodeConnectTransport(opts: NodeConnectTransportOptions): Transport {
+  const { baseUrl, profile, policy, getToken, onUnauthorized, useBinaryFormat, retry } = opts;
+
+  if (profile !== "service") {
+    throw new Error(
+      `configureNodeConnectTransport: profile must be "service" (got "${profile}"). ` +
+        "A Node process cannot issue browser requests, so the webapp profile has no " +
+        "meaning here — use @brefwiz/api-bones-connect/web in a browser composition root.",
+    );
+  }
+
+  // Parsed for its failure, not its result: indexGeneratedPolicy fails closed to
+  // an empty map, so an empty index alongside a non-empty document means the
+  // artifact is malformed or has duplicate RPCs. Catching that here stops a
+  // drifted policy from being noticed only once a webapp consumes it.
+  if (policy !== undefined) {
+    const index = indexGeneratedPolicy(policy);
+    const declared = (policy as { methods?: unknown })?.methods;
+    if (Array.isArray(declared) && declared.length > 0 && index.size === 0) {
+      throw new Error(
+        "configureNodeConnectTransport: connect-method-policy.json is malformed or has " +
+          "duplicate RPC entries. Regenerate it (check-connect-read-profile.py --write) " +
+          "rather than hand-editing.",
+      );
+    }
+  }
+
+  const interceptors: Interceptor[] = [
+    ...(opts.interceptors ?? []),
+    ...(getToken ? [makeAuthInterceptor(getToken)] : []),
+    ...(onUnauthorized ? [makeUnauthInterceptor(onUnauthorized)] : []),
+    makeRetryInterceptor(retry),
+  ];
+
+  return createConnectTransport({
+    baseUrl,
+    httpVersion: opts.httpVersion ?? "2",
+    useBinaryFormat: useBinaryFormat ?? false,
+    interceptors,
+    acceptCompression: [compressionGzip, compressionBrotli],
+  });
+}

--- a/api-bones-connect-ts/src/policy.ts
+++ b/api-bones-connect-ts/src/policy.ts
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: MIT
+//
+// The generated method-policy contract, shared by every transport profile.
+//
+// `connect-method-policy.json` is emitted from the proto surface by
+// ci-workflows' check-connect-read-profile.py (`--write`). It is a pure
+// function of the protos, so it is never hand-edited: regenerate and commit.
+//
+// Everything here is runtime-agnostic on purpose. The browser adapter uses it
+// to decide GET eligibility; the Node adapter carries the same vocabulary so a
+// service and a webapp describe their surface identically, even though a Node
+// transport can never issue a browser GET.
+
+/** Composition-root profile. Browser GET is opt-in through `webapp`. */
+export type SdkTransportProfile = "webapp" | "service";
+
+export interface GeneratedBrowserCachePolicy {
+  readonly scope: "PRIVATE" | "NO_STORE";
+  readonly maxAgeSeconds: number;
+}
+
+export interface GeneratedMethodPolicy {
+  readonly rpc: string;
+  readonly procedure: "unary" | "streaming";
+  readonly idempotency: "NO_SIDE_EFFECTS" | "IDEMPOTENT" | "UNSPECIFIED";
+  readonly browserCache: GeneratedBrowserCachePolicy;
+  readonly sensitivity: "NON_SENSITIVE" | "UNSPECIFIED";
+  readonly maxEncodedUrlBytes: number;
+}
+
+export interface GeneratedMethodPolicyDocument {
+  readonly schemaVersion: 1;
+  readonly methods: readonly GeneratedMethodPolicy[];
+}
+
+export const MAX_CONNECT_GET_URL_BYTES = 4096;
+export const MAX_PRIVATE_CACHE_TTL_SECONDS = 300;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return (
+    typeof value === "number" && Number.isFinite(value) && Number.isInteger(value) && value >= 0
+  );
+}
+
+export function parseMethodPolicy(value: unknown): GeneratedMethodPolicy | null {
+  if (!isRecord(value) || !isRecord(value.browserCache)) return null;
+  const cache = value.browserCache;
+  if (
+    typeof value.rpc !== "string" ||
+    !value.rpc.startsWith("/") ||
+    (value.procedure !== "unary" && value.procedure !== "streaming") ||
+    (value.idempotency !== "NO_SIDE_EFFECTS" &&
+      value.idempotency !== "IDEMPOTENT" &&
+      value.idempotency !== "UNSPECIFIED") ||
+    (cache.scope !== "PRIVATE" && cache.scope !== "NO_STORE") ||
+    !isNonNegativeInteger(cache.maxAgeSeconds) ||
+    (value.sensitivity !== "NON_SENSITIVE" && value.sensitivity !== "UNSPECIFIED") ||
+    !isNonNegativeInteger(value.maxEncodedUrlBytes) ||
+    value.maxEncodedUrlBytes > MAX_CONNECT_GET_URL_BYTES
+  ) {
+    return null;
+  }
+  return {
+    rpc: value.rpc,
+    procedure: value.procedure,
+    idempotency: value.idempotency,
+    browserCache: {
+      scope: cache.scope,
+      maxAgeSeconds: cache.maxAgeSeconds,
+    },
+    sensitivity: value.sensitivity,
+    maxEncodedUrlBytes: value.maxEncodedUrlBytes,
+  };
+}
+
+/**
+ * Index a policy document by RPC identity.
+ *
+ * Fails CLOSED to an empty map on any malformed or duplicated entry: a policy
+ * that cannot be trusted in full grants no browser reads at all, rather than
+ * silently granting the subset that happened to parse.
+ */
+export function indexGeneratedPolicy(value: unknown): ReadonlyMap<string, GeneratedMethodPolicy> {
+  if (!isRecord(value) || value.schemaVersion !== 1 || !Array.isArray(value.methods)) {
+    return new Map();
+  }
+  const index = new Map<string, GeneratedMethodPolicy>();
+  for (const candidate of value.methods) {
+    const method = parseMethodPolicy(candidate);
+    if (!method || index.has(method.rpc)) return new Map();
+    index.set(method.rpc, method);
+  }
+  return index;
+}
+
+/** Return policy only when it grants a bounded, non-sensitive browser read. */
+export function eligibleBrowserReadPolicy(value: unknown): GeneratedMethodPolicy | null {
+  const method = parseMethodPolicy(value);
+  if (
+    !method ||
+    method.procedure !== "unary" ||
+    method.idempotency !== "NO_SIDE_EFFECTS" ||
+    method.browserCache.scope !== "PRIVATE" ||
+    method.browserCache.maxAgeSeconds > MAX_PRIVATE_CACHE_TTL_SECONDS ||
+    method.sensitivity !== "NON_SENSITIVE" ||
+    method.maxEncodedUrlBytes <= 0
+  ) {
+    return null;
+  }
+  return method;
+}

--- a/api-bones-connect-ts/src/web.ts
+++ b/api-bones-connect-ts/src/web.ts
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: MIT
+//
+// Canonical browser Connect transport.
+//
+// Moved verbatim in behaviour from core-ui's src/api/connect-client.ts so the
+// two runtime adapters can share one policy vocabulary. Everything browser-only
+// stays here and only here: the CSRF meta-tag read, `credentials: "include"`,
+// and the GET transport. A Node service must never acquire those by importing a
+// transport — that is how a CLI ends up depending on `document`.
+
+import {
+  create,
+  type DescMessage,
+  type DescMethodUnary,
+  type MessageInitShape,
+  type MessageShape,
+} from "@bufbuild/protobuf";
+import { base64Encode } from "@bufbuild/protobuf/wire";
+import { Code, ConnectError, type Interceptor, type Transport } from "@connectrpc/connect";
+import { createClientMethodSerializers, createMethodUrl } from "@connectrpc/connect/protocol";
+import { createConnectTransport, createGrpcWebTransport } from "@connectrpc/connect-web";
+
+import type { BackoffOptions } from "./backoff";
+import { computeBackoffDelay, resolveBackoff } from "./backoff";
+import {
+  eligibleBrowserReadPolicy,
+  indexGeneratedPolicy,
+  MAX_CONNECT_GET_URL_BYTES,
+  type SdkTransportProfile,
+} from "./policy";
+
+export interface ConnectTransportOptions {
+  baseUrl: string;
+  /** Composition-root profile. Browser GET is opt-in through `webapp`. */
+  profile: SdkTransportProfile;
+  /** Generated, complete policy document emitted beside the SDK. */
+  policy: unknown;
+  /**
+   * BFF mode (default): omit this. The transport sends credentials (the opaque
+   * session cookie) on every request and never touches a bearer — no token ever
+   * lives in JS. Provide a `getToken` only for the legacy direct-bearer path;
+   * when present, `Authorization: Bearer <token>` is added.
+   */
+  getToken?: () => string | null | undefined;
+  /**
+   * Called when the server returns Unauthenticated. Typically triggers a logout
+   * or redirect to the login page.
+   */
+  onUnauthorized?: () => void;
+  /**
+   * Use binary protobuf encoding instead of JSON. Default: false (JSON, more
+   * debuggable in browser devtools).
+   */
+  useBinaryFormat?: boolean;
+  /** Fall back to gRPC-Web transport instead of Connect protocol. */
+  useGrpcWeb?: boolean;
+  /** Retry options for transient unary failures. */
+  retry?: BackoffOptions;
+  /** Product interceptors, including tracing, composed ahead of core interceptors. */
+  interceptors?: readonly Interceptor[];
+  /** Fetch override for browser adapters and focused transport tests. */
+  fetch?: typeof globalThis.fetch;
+}
+
+const RETRYABLE_CODES = new Set([Code.Unavailable, Code.Aborted, Code.ResourceExhausted]);
+const MAX_RETRIES = 3;
+
+function makeAuthInterceptor(getToken: () => string | null | undefined): Interceptor {
+  return (next) => (req) => {
+    const token = getToken();
+    if (token) {
+      req.header.set("Authorization", `Bearer ${token}`);
+    }
+    return next(req);
+  };
+}
+
+/** Read the CSRF synchronizer token rendered into the page `<meta>`. */
+function getCsrfTokenFromMeta(): string | null {
+  if (typeof document === "undefined") return null;
+  return document.querySelector('meta[name="csrf-token"]')?.getAttribute("content") || null;
+}
+
+/**
+ * Attach `X-CSRF-Token` to Connect requests. It protects POST fallbacks and is
+ * carried as a header, never as cache-key or URL material.
+ */
+function makeCsrfInterceptor(): Interceptor {
+  const token = getCsrfTokenFromMeta();
+  return (next) => (req) => {
+    if (token) {
+      req.header.set("X-CSRF-Token", token);
+    }
+    return next(req);
+  };
+}
+
+function makeUnauthInterceptor(onUnauthorized: () => void): Interceptor {
+  return (next) => async (req) => {
+    try {
+      return await next(req);
+    } catch (err) {
+      if (err instanceof ConnectError && err.code === Code.Unauthenticated) {
+        onUnauthorized();
+      }
+      throw err;
+    }
+  };
+}
+
+function makeRetryInterceptor(retryOpts?: BackoffOptions): Interceptor {
+  const backoff = resolveBackoff(retryOpts);
+  return (next) => async (req) => {
+    // Only retry unary requests — streams must handle reconnect separately.
+    if (req.stream) return next(req);
+
+    let attempt = 0;
+    for (;;) {
+      try {
+        return await next(req);
+      } catch (err) {
+        if (err instanceof ConnectError && RETRYABLE_CODES.has(err.code) && attempt < MAX_RETRIES) {
+          const delay = computeBackoffDelay(attempt, backoff);
+          await new Promise<void>((resolve) => setTimeout(resolve, delay));
+          attempt++;
+          continue;
+        }
+        throw err;
+      }
+    }
+  };
+}
+
+function rpcIdentity(method: DescMethodUnary): string {
+  return `/${method.parent.typeName}/${method.name}`;
+}
+
+function encodedConnectGetUrlBytes<I extends DescMessage, O extends DescMessage>(
+  baseUrl: string,
+  method: DescMethodUnary<I, O>,
+  input: MessageInitShape<I>,
+  useBinaryFormat: boolean,
+): number {
+  const { serialize } = createClientMethodSerializers(method, useBinaryFormat);
+  const message = create(method.input, input);
+  const bytes = serialize(message as MessageShape<I>);
+  const encodedMessage = useBinaryFormat
+    ? base64Encode(bytes, "url")
+    : encodeURIComponent(new TextDecoder().decode(bytes));
+  const query = useBinaryFormat
+    ? `?connect=v1&encoding=proto&base64=1&message=${encodedMessage}`
+    : `?connect=v1&encoding=json&message=${encodedMessage}`;
+  return new TextEncoder().encode(`${createMethodUrl(baseUrl, method)}${query}`).byteLength;
+}
+
+function withCredentials(fetchImpl: typeof globalThis.fetch): typeof globalThis.fetch {
+  return (input, init) =>
+    fetchImpl(input, {
+      ...init,
+      credentials: "include",
+      cache: init?.method === "GET" ? "no-cache" : init?.cache,
+    });
+}
+
+/**
+ * Build a Connect transport preconfigured for all brefwiz services.
+ *
+ * @example
+ * ```ts
+ * import { configureConnectTransport } from "@brefwiz/api-bones-connect/web";
+ * import { createClient } from "@connectrpc/connect";
+ * import { RulesService } from "./generated/rules_connect";
+ * import policy from "./generated/connect-method-policy.json";
+ *
+ * const transport = configureConnectTransport({
+ *   baseUrl: import.meta.env.VITE_API_URL,
+ *   profile: "webapp",
+ *   policy,
+ * });
+ *
+ * const rulesClient = createClient(RulesService, transport);
+ * ```
+ */
+export function configureConnectTransport(opts: ConnectTransportOptions): Transport {
+  const { baseUrl, profile, policy, getToken, onUnauthorized, useBinaryFormat, useGrpcWeb, retry } =
+    opts;
+  const policyByRpc = indexGeneratedPolicy(policy);
+
+  const interceptors: Interceptor[] = [
+    ...(opts.interceptors ?? []),
+    ...(getToken ? [makeAuthInterceptor(getToken)] : []),
+    makeCsrfInterceptor(),
+    ...(onUnauthorized ? [makeUnauthInterceptor(onUnauthorized)] : []),
+    makeRetryInterceptor(retry),
+  ];
+
+  const transportOpts = {
+    baseUrl,
+    useBinaryFormat: useBinaryFormat ?? false,
+    interceptors,
+    fetch: withCredentials(opts.fetch ?? globalThis.fetch),
+  };
+
+  const postTransport = useGrpcWeb
+    ? createGrpcWebTransport(transportOpts)
+    : createConnectTransport(transportOpts);
+  if (profile !== "webapp" || useGrpcWeb) return postTransport;
+
+  const getTransport = createConnectTransport({
+    ...transportOpts,
+    useHttpGet: true,
+  });
+
+  return {
+    async unary(method, signal, timeoutMs, header, input, contextValues) {
+      const methodPolicy = eligibleBrowserReadPolicy(policyByRpc.get(rpcIdentity(method)));
+      if (!methodPolicy) {
+        return postTransport.unary(method, signal, timeoutMs, header, input, contextValues);
+      }
+      const urlBytes = encodedConnectGetUrlBytes(baseUrl, method, input, useBinaryFormat ?? false);
+      const maxBytes = Math.min(MAX_CONNECT_GET_URL_BYTES, methodPolicy.maxEncodedUrlBytes);
+      const selected = urlBytes <= maxBytes ? getTransport : postTransport;
+      return selected.unary(method, signal, timeoutMs, header, input, contextValues);
+    },
+    stream(method, signal, timeoutMs, header, input, contextValues) {
+      return postTransport.stream(method, signal, timeoutMs, header, input, contextValues);
+    },
+  };
+}

--- a/api-bones-connect-ts/tsconfig.json
+++ b/api-bones-connect-ts/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "node_modules"]
+}


### PR DESCRIPTION
## What

New `@brefwiz/api-bones-connect` TypeScript package: the **canonical Connect transport**, with a shared runtime-agnostic core and two runtime adapters behind explicit subpaths.

```
@brefwiz/api-bones-connect        → policy contract + backoff (no runtime deps)
@brefwiz/api-bones-connect/web    → browser transport (profile-aware GET/POST)
@brefwiz/api-bones-connect/node   → NEW: Node/service transport
```

## Why

`connect-read-profile` flags every SDK that constructs a transport by hand — ~24 repos. But the only canonical helper lived in `@brefwiz/core-ui` and imports `@connectrpc/connect-web`, so a CLI, mesh service, or test harness had **nothing to migrate to**. The gate was unsatisfiable for service code.

api-bones is the right home: it already owns Connect as a cross-language concern (the `api-bones-connect` Rust crate), already ships TS to npm, and is the protocol layer rather than a UI package. A CLI depending on `@brefwiz/api-bones-connect` reads correctly; depending on `@brefwiz/core-ui` for a Node transport does not.

## Design notes

**The Node adapter rejects `profile: "webapp"`** rather than downgrading it. A Node process cannot issue a browser request, so accepting that value would silently accept a composition-root mistake.

**It accepts `policy` and uses it only to fail.** `indexGeneratedPolicy` fails closed to an empty map, so an empty index against a non-empty document means the artifact is malformed or has duplicate RPCs. Validating in services too keeps one artifact honest across both runtimes, instead of a drifted policy being noticed only when a webapp consumes it.

**Browser machinery stays in `/web` only** — the CSRF meta-tag read, `credentials: "include"`, and the GET transport. That separation is the point: it's how a CLI avoids acquiring a dependency on `document`.

## A near-miss worth recording

I first wrote `backoff.ts` from memory as `baseDelayMs`/`jitter` with a 250 ms base and 5 s cap. The real module is `initialDelayMs`/`multiplier`, **500 ms**, **30 s** cap, floored full jitter with an injectable `random`. Since core-ui's four subscription hooks consume it, that would have silently retimed every reconnect the moment core-ui switched over. It is now a verified verbatim copy, and the defaults are pinned **by value** in a test so relocating them again can't quietly change them.

## Also fixed

`ts-build`/`ts-test` hardcoded `api-bones-otel` alone, so **`api-bones-axios` had never had its build or tests run in CI** despite having both scripts. Now a `TS_PACKAGES` list, which makes an omission visible instead of silent.

## Verification

- `make ts-test`: 3 packages, **32 tests** green (otel 12, axios 8, connect 12)
- `tsc --noEmit` clean
- release axis added: `connect-v*` tags, tag/package.json version guard mirroring the axios and otel jobs
- `release.yml` parses; jobs wired

Next in the chain: core-ui re-exports from this package, then the ci-workflows adapter shapes, then consumer migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MHZhXRjHNVghtQdBEP56MW
