### PR TITLE
fix(connect): classify unreachable services in the web transport

### DIFF
--- a/api-bones-connect-ts/package-lock.json
+++ b/api-bones-connect-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brefwiz/api-bones-connect",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brefwiz/api-bones-connect",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "devDependencies": {
         "@bufbuild/protobuf": "^2.0.0",

--- a/api-bones-connect-ts/package.json
+++ b/api-bones-connect-ts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@brefwiz/api-bones-connect",
-  "version": "0.1.0",
-  "description": "Canonical Connect transport profiles for Brefwiz SDKs — shared policy core with browser and Node adapters",
+  "version": "0.1.1",
+  "description": "Canonical Connect transport profiles for Brefwiz SDKs \u2014 shared policy core with browser and Node adapters",
   "author": "Brefwiz Team",
   "license": "MIT",
   "main": "dist/index.js",
@@ -24,7 +24,9 @@
       "types": "./dist/node.d.ts"
     }
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
     "test": "vitest run"
@@ -34,8 +36,12 @@
     "@connectrpc/connect": "^2.0.0"
   },
   "peerDependenciesMeta": {
-    "@connectrpc/connect-web": { "optional": true },
-    "@connectrpc/connect-node": { "optional": true }
+    "@connectrpc/connect-web": {
+      "optional": true
+    },
+    "@connectrpc/connect-node": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@bufbuild/protobuf": "^2.0.0",

--- a/api-bones-connect-ts/src/web.ts
+++ b/api-bones-connect-ts/src/web.ts
@@ -153,13 +153,34 @@ function encodedConnectGetUrlBytes<I extends DescMessage, O extends DescMessage>
   return new TextEncoder().encode(`${createMethodUrl(baseUrl, method)}${query}`).byteLength;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Send credentials, and classify transport failures as Connect errors.
+ *
+ * Without the catch, a network-level failure escapes as a raw fetch TypeError,
+ * so callers see an opaque exception instead of a Connect code and cannot tell
+ * "server said no" from "server unreachable". Abort and timeout map to
+ * Canceled; everything else is Unavailable.
+ */
 function withCredentials(fetchImpl: typeof globalThis.fetch): typeof globalThis.fetch {
-  return (input, init) =>
-    fetchImpl(input, {
-      ...init,
-      credentials: "include",
-      cache: init?.method === "GET" ? "no-cache" : init?.cache,
-    });
+  return async (input, init) => {
+    try {
+      return await fetchImpl(input, {
+        ...init,
+        credentials: "include",
+        cache: init?.method === "GET" ? "no-cache" : init?.cache,
+      });
+    } catch (error) {
+      if (isRecord(error) && (error.name === "AbortError" || error.name === "TimeoutError")) {
+        const message = typeof error.message === "string" ? error.message : "request canceled";
+        throw new ConnectError(message, Code.Canceled, undefined, undefined, error);
+      }
+      throw ConnectError.from(error, Code.Unavailable);
+    }
+  };
 }
 
 /**


### PR DESCRIPTION
## What

Ports `fix(connect): classify unreachable services` (core-ui `9a41920`) into the web adapter, and releases 0.1.1.

## Why this is urgent

That commit landed on core-ui **while the transport was being extracted here**. The implementation had already been copied, so core-ui#338's rebase would have completed with the old `withCredentials` and **silently reverted a fix from the same day**.

It was caught only because the change happened to touch a conflicting line. Had it landed anywhere else in the file, the rebase would have merged clean and the regression would have shipped invisibly. That is the standing hazard of moving an actively-developed module: the window between copy and cutover is a window for silent reverts.

## The behaviour

Without the catch, a network-level failure escapes as a raw fetch `TypeError`, so callers cannot distinguish "server said no" from "server unreachable":

- `AbortError` / `TimeoutError` → `ConnectError(..., Code.Canceled)`
- everything else → `ConnectError.from(error, Code.Unavailable)`

## Test coverage

Deliberately not duplicated here. `withCredentials` is internal, and core-ui's suite (129 files / 1118 tests) already exercises this path — once core-ui#338 lands, those tests run against *this* implementation through the re-export, which is stronger than a mock-fetch unit test added alongside the copy.

`make ts-test`: 3 packages green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MHZhXRjHNVghtQdBEP56MW
