### PR TITLE
feat(connect)!: gate transport retries on declared method idempotency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,7 +109,7 @@ dependencies = [
  "proptest-derive",
  "rand 0.10.2",
  "rustls-native-certs",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -240,9 +240,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.42"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+checksum = "3976abdc8fe7d1133d43d304afd42abdf5bc3e1319d263d223bde07b5efc4be8"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -626,9 +626,9 @@ dependencies = [
 
 [[package]]
 name = "bytesize"
-version = "2.4.2"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d7c8918969267b2932ffd5655509bbbea0833823058c378876953217f5fc50e"
+checksum = "351a3e803ee3c6eaeee6b00076b767514b37c32a73d326c3ec7abddb7d6c3493"
 
 [[package]]
 name = "castaway"
@@ -641,9 +641,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -690,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.4"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -700,9 +700,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1091,13 +1091,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1156,9 +1156,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "email_address"
@@ -1555,9 +1555,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1600,9 +1600,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]
@@ -1737,9 +1737,9 @@ dependencies = [
 
 [[package]]
 name = "icalendar"
-version = "0.17.12"
+version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3478c3b7a2411366daf20457373174bff6cfbc1089333038b1f95594d23d985"
+checksum = "8fda1b791865374063fa57e84adfe3823c2d5cd5968d721533be4556a24cffd8"
 dependencies = [
  "chrono",
  "iso8601",
@@ -1904,9 +1904,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "iso8601"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1082f0c48f143442a1ac6122f67e360ceee130b967af4d50996e5154a45df46"
+checksum = "74a0559b45528cf0732d911524974977a5749f477d7dd99652830ffdaf53c4d1"
 dependencies = [
  "nom",
 ]
@@ -2443,9 +2443,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error-attr3"
-version = "3.0.2"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34e4dd828515431dd6c4a030d26f7eaed7dd4778226e9d2bb968d65ca4ec3d4d"
+checksum = "b0084e6206a967a2dad822180626b2f6b07a3b379325e8f1ec0438e33a469ba7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2453,14 +2453,14 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error3"
-version = "3.0.2"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee475e440453418ff1335189eddf7101ba502cd818ab7ae04209bc83aa925aa"
+checksum = "0cf066225f2373bc711684792b69bdeac0356019b007e721090c24d92d5d5a50"
 dependencies = [
  "proc-macro-error-attr3",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2958,9 +2958,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.42"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -2986,9 +2986,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3103,14 +3103,14 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
  "chrono",
  "dyn-clone",
  "ref-cast",
- "schemars_derive 1.2.1",
+ "schemars_derive 1.2.2",
  "serde",
  "serde_json",
  "uuid",
@@ -3124,20 +3124,20 @@ checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
 dependencies = [
  "proc-macro2",
  "quote",
- "serde_derive_internals",
+ "serde_derive_internals 0.29.1",
  "syn 2.0.119",
 ]
 
 [[package]]
 name = "schemars_derive"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+checksum = "d98c67716b46af2f0b8cf752abc930f6f9aecfbf671ecfb531db8a31dbe4e2ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "serde_derive_internals",
- "syn 2.0.119",
+ "serde_derive_internals 0.30.0",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3221,6 +3221,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_derive_internals"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3301,7 +3312,7 @@ dependencies = [
  "indexmap 1.9.3",
  "indexmap 2.14.0",
  "schemars 0.9.0",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde_core",
  "serde_json",
  "serde_with_macros",
@@ -3639,9 +3650,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
  "num-conv",
@@ -3711,13 +3722,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/api-bones-connect-ts/package-lock.json
+++ b/api-bones-connect-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brefwiz/api-bones-connect",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brefwiz/api-bones-connect",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "@bufbuild/protobuf": "^2.0.0",

--- a/api-bones-connect-ts/package.json
+++ b/api-bones-connect-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brefwiz/api-bones-connect",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Canonical Connect transport profiles for Brefwiz SDKs \u2014 shared policy core with browser and Node adapters",
   "author": "Brefwiz Team",
   "license": "MIT",

--- a/api-bones-connect-ts/src/index.test.ts
+++ b/api-bones-connect-ts/src/index.test.ts
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: MIT
+import { Code, ConnectError } from "@connectrpc/connect";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -12,6 +13,12 @@ import {
   indexGeneratedPolicy,
 } from "./policy";
 import { configureNodeConnectTransport } from "./node";
+import {
+  RetryThrottle,
+  isRetryableMethod,
+  serverPushbackMs,
+} from "./retry";
+import type { GeneratedMethodPolicy } from "./policy";
 
 const method = (over: Record<string, unknown> = {}) => ({
   rpc: "/svc.v1.S/Get",
@@ -124,5 +131,55 @@ describe("node transport", () => {
         policy: { schemaVersion: 1, methods: [method(), method()] },
       }),
     ).toThrow(/malformed or has duplicate RPC entries/);
+  });
+});
+
+describe("retry eligibility", () => {
+  const unary = (idempotency: GeneratedMethodPolicy["idempotency"]): GeneratedMethodPolicy => ({
+    rpc: "/pkg.v1.Svc/Method",
+    procedure: "unary",
+    idempotency,
+    browserCache: { scope: "NO_STORE", maxAgeSeconds: 0 },
+    sensitivity: "UNSPECIFIED",
+    maxEncodedUrlBytes: 4096,
+  });
+
+  it("retries only methods the proto declares safe", () => {
+    expect(isRetryableMethod(unary("NO_SIDE_EFFECTS"))).toBe(true);
+    expect(isRetryableMethod(unary("IDEMPOTENT"))).toBe(true);
+    // The case that matters: an unannotated method is NOT replayed. Bootstrap
+    // token redemption is single-use, and Connect can report Unavailable after
+    // the server already accepted the call.
+    expect(isRetryableMethod(unary("UNSPECIFIED"))).toBe(false);
+  });
+
+  it("fails closed with no policy entry or on streams", () => {
+    expect(isRetryableMethod(undefined)).toBe(false);
+    expect(isRetryableMethod({ ...unary("NO_SIDE_EFFECTS"), procedure: "streaming" })).toBe(false);
+  });
+
+  it("reads Retry-After in both delay-seconds and HTTP-date form", () => {
+    const withHeader = (value: string): ConnectError => {
+      const err = new ConnectError("throttled", Code.ResourceExhausted);
+      err.metadata.set("retry-after", value);
+      return err;
+    };
+    expect(serverPushbackMs(withHeader("2"))).toBe(2000);
+    const now = Date.parse("2026-01-01T00:00:00Z");
+    expect(serverPushbackMs(withHeader("Thu, 01 Jan 2026 00:00:30 GMT"), now)).toBe(30000);
+    expect(serverPushbackMs(withHeader("nonsense"))).toBeNull();
+    expect(serverPushbackMs(new ConnectError("x", Code.Unavailable))).toBeNull();
+  });
+
+  it("suspends retries once the budget drains", () => {
+    const throttle = new RetryThrottle({ maxTokens: 4, tokenRatio: 0.1 });
+    expect(throttle.canRetry).toBe(true);
+    throttle.recordFailure();
+    throttle.recordFailure();
+    // 4 -> 2, which is not above half of 4: a sustained outage stops retrying
+    // instead of multiplying the load that caused it.
+    expect(throttle.canRetry).toBe(false);
+    for (let i = 0; i < 20; i++) throttle.recordSuccess();
+    expect(throttle.canRetry).toBe(true);
   });
 });

--- a/api-bones-connect-ts/src/index.ts
+++ b/api-bones-connect-ts/src/index.ts
@@ -30,3 +30,14 @@ export {
   type GeneratedMethodPolicyDocument,
   type SdkTransportProfile,
 } from "./policy";
+
+export {
+  MAX_RETRY_ATTEMPTS,
+  RetryThrottle,
+  isRetryableMethod,
+  makeRetryInterceptor,
+  rpcIdentity,
+  serverPushbackMs,
+  type RetryInterceptorOptions,
+  type RetryThrottleOptions,
+} from "./retry";

--- a/api-bones-connect-ts/src/node.ts
+++ b/api-bones-connect-ts/src/node.ts
@@ -25,11 +25,8 @@ import {
 } from "@connectrpc/connect-node";
 
 import type { BackoffOptions } from "./backoff";
-import { computeBackoffDelay, resolveBackoff } from "./backoff";
 import { indexGeneratedPolicy, type SdkTransportProfile } from "./policy";
-
-const RETRYABLE_CODES = new Set([Code.Unavailable, Code.Aborted, Code.ResourceExhausted]);
-const MAX_RETRIES = 3;
+import { makeRetryInterceptor } from "./retry";
 
 export interface NodeConnectTransportOptions {
   baseUrl: string;
@@ -85,29 +82,6 @@ function makeUnauthInterceptor(onUnauthorized: () => void): Interceptor {
   };
 }
 
-function makeRetryInterceptor(retryOpts?: BackoffOptions): Interceptor {
-  const backoff = resolveBackoff(retryOpts);
-  return (next) => async (req) => {
-    // Only retry unary requests — streams must handle reconnect separately.
-    if (req.stream) return next(req);
-
-    let attempt = 0;
-    for (;;) {
-      try {
-        return await next(req);
-      } catch (err) {
-        if (err instanceof ConnectError && RETRYABLE_CODES.has(err.code) && attempt < MAX_RETRIES) {
-          const delay = computeBackoffDelay(attempt, backoff);
-          await new Promise<void>((resolve) => setTimeout(resolve, delay));
-          attempt++;
-          continue;
-        }
-        throw err;
-      }
-    }
-  };
-}
-
 /**
  * Build the canonical Connect transport for a Node service, CLI, or harness.
  *
@@ -138,14 +112,17 @@ export function configureNodeConnectTransport(opts: NodeConnectTransportOptions)
     );
   }
 
-  // Parsed for its failure, not its result: indexGeneratedPolicy fails closed to
-  // an empty map, so an empty index alongside a non-empty document means the
-  // artifact is malformed or has duplicate RPCs. Catching that here stops a
-  // drifted policy from being noticed only once a webapp consumes it.
+  // Parsed for its failure as well as its result: indexGeneratedPolicy fails
+  // closed to an empty map, so an empty index alongside a non-empty document
+  // means the artifact is malformed or has duplicate RPCs. Catching that here
+  // stops a drifted policy from being noticed only once a webapp consumes it.
+  //
+  // The same index then decides retry eligibility, so a service that ships no
+  // policy simply gets no retries rather than blind ones.
+  const policyByRpc = indexGeneratedPolicy(policy);
   if (policy !== undefined) {
-    const index = indexGeneratedPolicy(policy);
     const declared = (policy as { methods?: unknown })?.methods;
-    if (Array.isArray(declared) && declared.length > 0 && index.size === 0) {
+    if (Array.isArray(declared) && declared.length > 0 && policyByRpc.size === 0) {
       throw new Error(
         "configureNodeConnectTransport: connect-method-policy.json is malformed or has " +
           "duplicate RPC entries. Regenerate it (check-connect-read-profile.py --write) " +
@@ -158,7 +135,7 @@ export function configureNodeConnectTransport(opts: NodeConnectTransportOptions)
     ...(opts.interceptors ?? []),
     ...(getToken ? [makeAuthInterceptor(getToken)] : []),
     ...(onUnauthorized ? [makeUnauthInterceptor(onUnauthorized)] : []),
-    makeRetryInterceptor(retry),
+    makeRetryInterceptor({ policyByRpc, backoff: retry }),
   ];
 
   return createConnectTransport({

--- a/api-bones-connect-ts/src/retry.ts
+++ b/api-bones-connect-ts/src/retry.ts
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: MIT
+//
+// Retry eligibility, derived from the proto surface rather than configured.
+//
+// Both adapters previously retried every unary call on Unavailable, Aborted and
+// ResourceExhausted, with no knowledge of what the call did. That is the one
+// thing every mature RPC client refuses to do: gRPC ships retries off by default
+// and requires a per-method service config (gRFC A6); Google's client libraries
+// retry only methods their API config declares idempotent; Stripe makes POST
+// retries safe by requiring a client-supplied idempotency key. The common thread
+// is that retry safety is a property of the METHOD, not of the transport.
+//
+// The generated policy artifact already carries that property per RPC —
+// `idempotency` is emitted straight from the proto — so eligibility is read from
+// it instead of being restated as a knob. A method nobody has annotated is not
+// retried: unknown is treated as unsafe, so the blast radius of adding retries
+// grows only as fast as somebody deliberately declares a method safe.
+//
+// Why this matters concretely: single-use credential redemption (bootstrap-token
+// enrolment) is exactly the shape that must never be blind-retried. Connect can
+// surface Unavailable AFTER the server accepted the request, so a retry burns
+// the token and the operator sees "already used" instead of a network error.
+
+import { Code, ConnectError, type Interceptor } from "@connectrpc/connect";
+
+import type { BackoffOptions } from "./backoff";
+import { computeBackoffDelay, resolveBackoff } from "./backoff";
+import type { GeneratedMethodPolicy } from "./policy";
+
+/**
+ * Codes retried without any server instruction.
+ *
+ * Only Unavailable: it is the one code that reliably means "this connection did
+ * not carry the call". Aborted is deliberately absent — it signals a concurrency
+ * or transaction conflict, and the correct response is to re-run the enclosing
+ * transaction, not to replay one RPC inside it. ResourceExhausted is absent too;
+ * it is handled below only under explicit server pushback, because retrying a
+ * quota rejection on our own schedule is how a degraded service is converted
+ * into a fully saturated one.
+ */
+const UNPROMPTED_RETRYABLE_CODES: ReadonlySet<Code> = new Set([Code.Unavailable]);
+
+/** Attempts after the initial call. */
+export const MAX_RETRY_ATTEMPTS = 3;
+
+export interface RetryThrottleOptions {
+  /** Bucket capacity. Default 10. */
+  readonly maxTokens?: number;
+  /** Tokens returned per success. Default 0.1. */
+  readonly tokenRatio?: number;
+}
+
+/**
+ * A retry budget, modelled on gRPC's retry throttling.
+ *
+ * Backoff alone paces a single caller; it does nothing about many callers all
+ * retrying a service that is already failing. The bucket drains on retryable
+ * failures and refills slowly on success, so a broad outage suspends retries
+ * altogether instead of multiplying the load that caused it — the standard
+ * defence against a retry storm turning a partial outage into a total one.
+ */
+export class RetryThrottle {
+  readonly #maxTokens: number;
+  readonly #tokenRatio: number;
+  #tokens: number;
+
+  constructor(opts: RetryThrottleOptions = {}) {
+    this.#maxTokens = opts.maxTokens ?? 10;
+    this.#tokenRatio = opts.tokenRatio ?? 0.1;
+    this.#tokens = this.#maxTokens;
+  }
+
+  /** Retries are permitted while the bucket is above half full. */
+  get canRetry(): boolean {
+    return this.#tokens > this.#maxTokens / 2;
+  }
+
+  recordFailure(): void {
+    this.#tokens = Math.max(0, this.#tokens - 1);
+  }
+
+  recordSuccess(): void {
+    this.#tokens = Math.min(this.#maxTokens, this.#tokens + this.#tokenRatio);
+  }
+}
+
+/** `/package.Service/Method`, the identity the policy artifact is keyed by. */
+export function rpcIdentity(method: {
+  readonly name: string;
+  readonly parent: { readonly typeName: string };
+}): string {
+  return `/${method.parent.typeName}/${method.name}`;
+}
+
+/**
+ * Whether a method may be replayed at all.
+ *
+ * Fails closed on every uncertain input: no policy entry, a streaming method, or
+ * an unannotated one all return false. An SDK that ships without its generated
+ * policy therefore behaves exactly as it did before retries existed.
+ */
+export function isRetryableMethod(policy: GeneratedMethodPolicy | undefined): boolean {
+  if (!policy || policy.procedure !== "unary") return false;
+  return policy.idempotency === "NO_SIDE_EFFECTS" || policy.idempotency === "IDEMPOTENT";
+}
+
+/**
+ * Server-requested delay in milliseconds, or null when the server said nothing.
+ *
+ * Accepts both `Retry-After` forms: delay-seconds and an HTTP-date.
+ */
+export function serverPushbackMs(err: ConnectError, now: number = Date.now()): number | null {
+  const raw = err.metadata?.get("retry-after");
+  if (raw === null || raw === undefined || raw.trim() === "") return null;
+
+  const seconds = Number(raw);
+  if (Number.isFinite(seconds)) return seconds >= 0 ? Math.round(seconds * 1000) : null;
+
+  const at = Date.parse(raw);
+  if (Number.isNaN(at)) return null;
+  return Math.max(0, at - now);
+}
+
+export interface RetryInterceptorOptions {
+  /** Generated policy, indexed by RPC. An empty map disables retries entirely. */
+  readonly policyByRpc: ReadonlyMap<string, GeneratedMethodPolicy>;
+  readonly backoff?: BackoffOptions;
+  readonly throttle?: RetryThrottleOptions;
+  /** Injected so tests need no real delay. */
+  readonly sleep?: (ms: number) => Promise<void>;
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/** Retry interceptor shared by the browser and Node adapters. */
+export function makeRetryInterceptor(opts: RetryInterceptorOptions): Interceptor {
+  const backoff = resolveBackoff(opts.backoff);
+  const throttle = new RetryThrottle(opts.throttle);
+  const sleep = opts.sleep ?? defaultSleep;
+
+  return (next) => async (req) => {
+    // Streams reconnect on their own terms; replaying one here would restart a
+    // subscription mid-flight rather than resume it.
+    if (req.stream) return next(req);
+    if (!isRetryableMethod(opts.policyByRpc.get(rpcIdentity(req.method)))) return next(req);
+
+    let attempt = 0;
+    for (;;) {
+      try {
+        const response = await next(req);
+        throttle.recordSuccess();
+        return response;
+      } catch (err) {
+        if (!(err instanceof ConnectError) || attempt >= MAX_RETRY_ATTEMPTS) throw err;
+
+        const pushbackMs = serverPushbackMs(err);
+        const retryable =
+          UNPROMPTED_RETRYABLE_CODES.has(err.code) ||
+          (err.code === Code.ResourceExhausted && pushbackMs !== null);
+        if (!retryable) throw err;
+
+        throttle.recordFailure();
+        if (!throttle.canRetry) throw err;
+
+        // Server pushback outranks our own schedule: it is the only party that
+        // knows when it will be ready.
+        await sleep(pushbackMs ?? computeBackoffDelay(attempt, backoff));
+        attempt++;
+      }
+    }
+  };
+}

--- a/api-bones-connect-ts/src/web.ts
+++ b/api-bones-connect-ts/src/web.ts
@@ -21,13 +21,13 @@ import { createClientMethodSerializers, createMethodUrl } from "@connectrpc/conn
 import { createConnectTransport, createGrpcWebTransport } from "@connectrpc/connect-web";
 
 import type { BackoffOptions } from "./backoff";
-import { computeBackoffDelay, resolveBackoff } from "./backoff";
 import {
   eligibleBrowserReadPolicy,
   indexGeneratedPolicy,
   MAX_CONNECT_GET_URL_BYTES,
   type SdkTransportProfile,
 } from "./policy";
+import { makeRetryInterceptor, rpcIdentity } from "./retry";
 
 export interface ConnectTransportOptions {
   baseUrl: string;
@@ -61,9 +61,6 @@ export interface ConnectTransportOptions {
   /** Fetch override for browser adapters and focused transport tests. */
   fetch?: typeof globalThis.fetch;
 }
-
-const RETRYABLE_CODES = new Set([Code.Unavailable, Code.Aborted, Code.ResourceExhausted]);
-const MAX_RETRIES = 3;
 
 function makeAuthInterceptor(getToken: () => string | null | undefined): Interceptor {
   return (next) => (req) => {
@@ -106,33 +103,6 @@ function makeUnauthInterceptor(onUnauthorized: () => void): Interceptor {
       throw err;
     }
   };
-}
-
-function makeRetryInterceptor(retryOpts?: BackoffOptions): Interceptor {
-  const backoff = resolveBackoff(retryOpts);
-  return (next) => async (req) => {
-    // Only retry unary requests — streams must handle reconnect separately.
-    if (req.stream) return next(req);
-
-    let attempt = 0;
-    for (;;) {
-      try {
-        return await next(req);
-      } catch (err) {
-        if (err instanceof ConnectError && RETRYABLE_CODES.has(err.code) && attempt < MAX_RETRIES) {
-          const delay = computeBackoffDelay(attempt, backoff);
-          await new Promise<void>((resolve) => setTimeout(resolve, delay));
-          attempt++;
-          continue;
-        }
-        throw err;
-      }
-    }
-  };
-}
-
-function rpcIdentity(method: DescMethodUnary): string {
-  return `/${method.parent.typeName}/${method.name}`;
 }
 
 function encodedConnectGetUrlBytes<I extends DescMessage, O extends DescMessage>(
@@ -212,7 +182,7 @@ export function configureConnectTransport(opts: ConnectTransportOptions): Transp
     ...(getToken ? [makeAuthInterceptor(getToken)] : []),
     makeCsrfInterceptor(),
     ...(onUnauthorized ? [makeUnauthInterceptor(onUnauthorized)] : []),
-    makeRetryInterceptor(retry),
+    makeRetryInterceptor({ policyByRpc, backoff: retry }),
   ];
 
   const transportOpts = {


### PR DESCRIPTION
## Why

Both Connect adapters retried **every** unary call on `Unavailable`, `Aborted` and `ResourceExhausted`, with no knowledge of what the call did.

That is the one thing mature RPC clients refuse to do:

- **gRPC** ships retries *off* by default and requires a per-method service config (gRFC A6), with an explicit `retryableStatusCodes` list and a retry throttle.
- **Google Cloud client libraries** retry only methods their API config declares idempotent.
- **AWS SDKs** default to 3 attempts, safe largely because their APIs are idempotent or take idempotency tokens.
- **Stripe** makes POST retries safe only via a client-supplied idempotency key the server dedupes.

The common thread: **retry safety is a property of the method, not of the transport.**

## The concrete risk

This isn't theoretical for us. Single-use credential redemption — bootstrap-token enrolment — is exactly the shape that must never be blind-retried. Connect can surface `Unavailable` *after* the server accepted the request, so a retry burns the token and the operator sees `bootstrap token revoked or already used` instead of a network error. Intermittent, and naturally misattributed to the network.

In quorumauth today, `IssueBootstrapToken`, `Enroll` and `AttestationEnroll` are all unannotated — 93 of 94 RPCs are `UNSPECIFIED`.

## What changed

Eligibility is now **derived, not configured**. The generated policy artifact already carries `idempotency` per RPC straight from the proto, so the interceptor reads it rather than restating it as a knob.

- Retry only methods declared `NO_SIDE_EFFECTS` or `IDEMPOTENT`. Unannotated, streaming, or absent-from-policy all fail closed.
- `Unavailable` is the only unprompted retryable code.
- `Aborted` dropped — it signals a transaction conflict; the correct response is re-running the enclosing transaction, not replaying one RPC inside it.
- `ResourceExhausted` retries only under explicit `Retry-After` pushback (both delay-seconds and HTTP-date forms), honouring the server's schedule instead of ours.
- Added a gRPC-style retry throttle. Backoff paces one caller; it does nothing about a fleet all retrying a service that is already failing. The bucket drains on retryable failures and refills slowly on success, so a broad outage suspends retries rather than amplifying the load that caused it.
- The interceptor duplicated in `node.ts` and `web.ts` is now one shared `retry.ts`.

A nice property: with almost nothing annotated, retries stay off until a proto author deliberately declares a method safe, and light up per method as annotations land.

## Breaking

`0.1.1` → `0.2.0`. Retries now require the generated policy document; a transport built without `policy` retries nothing — matching pre-retry behaviour rather than silently replaying calls.

## Tests

`ts-test` green (16 in this package, up from 12), `ts-lint` and `ts-build` green, Rust `ci-lint`/`ci-test` green. New cases pin the dangerous ones: unannotated methods are not retried, no-policy and streaming fail closed, `Retry-After` parses in both forms, and the budget suspends retries once drained.
