### PR TITLE
chore(release): api-bones-connect 0.2.2

### DIFF
--- a/api-bones-connect-ts/package-lock.json
+++ b/api-bones-connect-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@brefwiz/api-bones-connect",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@brefwiz/api-bones-connect",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "devDependencies": {
         "@bufbuild/protobuf": "^2.0.0",

--- a/api-bones-connect-ts/package.json
+++ b/api-bones-connect-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brefwiz/api-bones-connect",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Canonical Connect transport profiles for Brefwiz SDKs \u2014 shared policy core with browser and Node adapters",
   "author": "Brefwiz Team",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Release `@brefwiz/api-bones-connect` 0.2.2, shipping the connection-write-failure retry merged in #135.

A call whose write never reached the server (a keep-alive socket the peer already closed, surfacing as `Internal` + `write EPIPE`) is now replayed. Eligibility is unchanged: `isRetryableMethod` still gates every retry on the method declared idempotency.

`connect-v0.2.1` is already published and the manifest still named that version, so the release tag guard would have rejected a re-release at 0.2.1.

After merge, tagging `connect-v0.2.2` publishes the package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
